### PR TITLE
Redo of PR #14, `#include afxwin.h`/Python2x workaround

### DIFF
--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -395,7 +395,19 @@ bool IsWindowsServer()
 std::wstring FindPython()
 {
 #pragma warning(suppress:4996)
-	const wchar_t* path = _wgetenv(L"path");
+	PCWSTR const pytwoseven = _wgetenv( L"python27" );
+	
+	//Some people, like me, (Alexander Riccio) have an environment variable 
+	//that specifically points to Python 2.7.
+	//As a workaround for issue #13, we'll use that version of Python.
+	//See the issue: https://github.com/google/UIforETW/issues/13
+	if ( pytwoseven )
+	{
+		return pytwoseven;
+	}
+
+#pragma warning(suppress:4996)	
+    const wchar_t* path = _wgetenv(L"path");
 	if (path)
 	{
 		std::vector<std::wstring> pathParts = split(path, ';');

--- a/UIforETW/stdafx.h
+++ b/UIforETW/stdafx.h
@@ -20,6 +20,7 @@ limitations under the License.
 #define VC_EXTRALEAN            // Exclude rarely-used stuff from Windows headers
 #endif
 
+#include <afxwin.h>         // MFC core and standard components //THIS NEEDS TO BE THE VERY FIRST INCLUDE!
 #include "targetver.h"
 
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS      // some CString constructors will be explicit
@@ -27,7 +28,6 @@ limitations under the License.
 // turns off MFC's hiding of some common and often safely ignored warning messages
 #define _AFX_ALL_WARNINGS
 
-#include <afxwin.h>         // MFC core and standard components
 #include <afxext.h>         // MFC extensions
 
 


### PR DESCRIPTION
Of course, I accidentally named this branch "retry-pr-13", instead of "retry-pr-14". Nonetheless, this is a repeat of pull request #14 - with the fixes requested in a comment on [pull request #13](https://github.com/google/UIforETW/pull/14).

There are two components to this pull request:

* A workaround for issue #13 - so that I can use UIforETW in the meantime. The branch is called "switch-to-subprocess" because I originally thought that os.popen was the problem, and tried to solve it in 86cd03c299b70c521da2c534a5b3acc882de7bd8

* A fix for insane compilation errors: I moved #include <afxwin.h> to the top of stdafx.h, because some people (like me) can't compile MFC programs if it isn't the first include. I think it has something to do with Voodoo.

I've gotten used to (the issue with including afxwin.h), but it is CRAZY HARD to actually figure out that **not** including afxwin.h first is the cause of ~~400 errors~~ your misery.