### PR TITLE
Python cleanup & minor refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *Generated*
 # Excluded most executables, but include a few specific ones.
 *.exe
-
+*.pyc
 *.ilk
 *.pdb
 Debug/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ GuidStats.txt
 Log.txt
 present.txt
 *.exe.lastcodeanalysissucceeded
+
+# XperfProcessParentage.py drops this
+Processes_Summary_Table_ProcessParentage.csv

--- a/bin/ETWPackSymbols.py
+++ b/bin/ETWPackSymbols.py
@@ -18,111 +18,115 @@ import re
 import shutil
 import sys
 
+def main():
 
+  if len(sys.argv) < 3:
+    print("Syntax: PackETWSymbols ETWFilename.etl destdirname [-verbose]")
+    print("This script looks for symbols needed to decode the specified trace, and")
+    print("copies them to the specified directory. This allows moving traces to")
+    print("other machines for analysis and sharing.")
+    sys.exit(0)
 
-if len(sys.argv) < 3:
-  print( "Syntax: PackETWSymbols ETWFilename.etl destdirname [-verbose]" )
-  print( "This script looks for symbols needed to decode the specified trace, and" )
-  print( "copies them to the specified directory. This allows moving traces to" )
-  print( "other machines for analysis and sharing." )
-  sys.exit(0)
+  ETLName = sys.argv[1]
+  DestDirName = sys.argv[2]
+  if not os.path.exists(DestDirName):
+    os.mkdir(DestDirName)
 
-ETLName = sys.argv[1]
-DestDirName = sys.argv[2]
-if not os.path.exists(DestDirName):
-  os.mkdir(DestDirName)
+  verbose = False
+  if len(sys.argv) > 3 and sys.argv[3].lower() == "-verbose":
+    verbose = True
 
-verbose = False
-if len(sys.argv) > 3 and sys.argv[3].lower() == "-verbose":
-  verbose = True
+  print("Extracting symbols from ETL file '%s'." % ETLName)
 
-print( "Extracting symbols from ETL file '%s'." % ETLName )
+  # This command is slow but thorough -- it tries to build the symbol cache.
+  #command = "xperf.exe -i \"%s\" -tle -symbols -a symcache -quiet -build -imageid -dbgid" % ETLName
+  # This command is faster. It relies on symbols being loaded already for the modules of interest.
+  command = "xperf.exe -i \"%s\" -tle -a symcache -quiet -imageid -dbgid" % ETLName
 
-# This command is slow but thorough -- it tries to build the symbol cache.
-#command = "xperf.exe -i \"%s\" -tle -symbols -a symcache -quiet -build -imageid -dbgid" % ETLName
-# This command is faster. It relies on symbols being loaded already for the modules of interest.
-command = "xperf.exe -i \"%s\" -tle -a symcache -quiet -imageid -dbgid" % ETLName
+  print("Executing command '%s'" % command)
+  lines = os.popen(command).readlines()
 
-print( "Executing command '%s'" % command )
-lines = os.popen(command).readlines()
+  if len(lines) < 30:
+    print("Error:")
+    for line in lines:
+      print(line, end='')
+    sys.exit(0)
 
-if len(lines) < 30:
-  print( "Error:" )
+  # Typical output lines (including one heading) look like this:
+  #TimeDateStamp,  ImageSize, OrigFileName, CodeView Record
+  #   0x4da89d03, 0x00bcb000, "client.dll", "[RSDS] PdbSig: {7b2a9028-87cd-448d-8500-1a18cdcf6166}; Age: 753; Pdb: u:\buildbot\dota_staging_win32\build\src\game\client\Release_dota\client.pdb"
+
+  scan = re.compile(r'   0x(.*), 0x(.*), "(.*)", "\[RSDS\].*; Pdb: (.*)"')
+
+  matchCount = 0
+  matchExists = 0
+  ourModuleCount = 0
+
+  # Get the users build directory
+  vgame = os.getenv("vgame")
+  if vgame == None:
+    print("Environment variable 'vgame' not found!")
+    sys.exit(-1)
+  vgame = vgame[:-5].lower()
+
+  prefixes = ["u:\\", "e:\\build_slave", vgame]
+
+  print("Looking for symbols built to:")
+  for prefix in prefixes:
+    print("    %s" % prefix)
+
+  # Default to looking for the SymCache on the C drive
+  prefix = "c"
+  # Look for a drive letter in the ETL Name and use that if present
+  if len(ETLName) > 1 and ETLName[1] == ':':
+    prefix = ETLName[0]
+  else:
+    # If there's no drive letter in the ETL name then look for one
+    # in the current working directory.
+    curwd = os.getcwd()
+    if len(curwd) > 1 and curwd[1] == ':':
+      prefix = curwd[0]
+
+  symCachePathBase = os.getenv("_NT_SYMCACHE_PATH");
+  if symCachePathBase == None or len(symCachePathBase) == 0:
+    symCachePathBase = "%s:\\symcache\\" % prefix
+  elif symCachePathBase[-1] != '\\':
+    symCachePathBase += '\\'
+
   for line in lines:
-    print( line, end='')
-  sys.exit(0)
+    result = scan.match(line)
+    if result is not None:
+      #print result.groups()
+      matchCount += 1
+      TimeDateStamp = result.groups()[0]
+      ImageSize = result.groups()[1]
+      OrigFileName = result.groups()[2]
+      PDBPath = result.groups()[3].lower()
 
-# Typical output lines (including one heading) look like this:
-#TimeDateStamp,  ImageSize, OrigFileName, CodeView Record
-#   0x4da89d03, 0x00bcb000, "client.dll", "[RSDS] PdbSig: {7b2a9028-87cd-448d-8500-1a18cdcf6166}; Age: 753; Pdb: u:\buildbot\dota_staging_win32\build\src\game\client\Release_dota\client.pdb"
-
-scan = re.compile(r'   0x(.*), 0x(.*), "(.*)", "\[RSDS\].*; Pdb: (.*)"')
-
-matchCount = 0
-matchExists = 0
-ourModuleCount = 0
-
-# Get the users build directory
-vgame = os.getenv("vgame")
-if vgame == None:
-  print( "Environment variable 'vgame' not found!" )
-  sys.exit(-1)
-vgame = vgame[:-5].lower()
-
-prefixes = ["u:\\", "e:\\build_slave", vgame]
-
-print( "Looking for symbols built to:" )
-for prefix in prefixes:
-  print( "    %s" % prefix )
-
-# Default to looking for the SymCache on the C drive
-prefix = "c"
-# Look for a drive letter in the ETL Name and use that if present
-if len(ETLName) > 1 and ETLName[1] == ':':
-  prefix = ETLName[0]
-else:
-  # If there's no drive letter in the ETL name then look for one
-  # in the current working directory.
-  curwd = os.getcwd()
-  if len(curwd) > 1 and curwd[1] == ':':
-    prefix = curwd[0]
-
-symCachePathBase = os.getenv("_NT_SYMCACHE_PATH");
-if symCachePathBase == None or len(symCachePathBase) == 0:
-  symCachePathBase = "%s:\\symcache\\" % prefix
-elif symCachePathBase[-1] != '\\':
-  symCachePathBase += '\\'
-
-for line in lines:
-  result = scan.match(line)
-  if result is not None:
-    #print result.groups()
-    matchCount += 1
-    TimeDateStamp = result.groups()[0]
-    ImageSize = result.groups()[1]
-    OrigFileName = result.groups()[2]
-    PDBPath = result.groups()[3].lower()
-
-    # Find out which PDBs are 'interesting'. There is no obvious heuristic
-    # for this, but having a list of prefixes seems like a good start.
-    ours = False
-    for prefix in prefixes:
-      if PDBPath.startswith(prefix):
+      # Find out which PDBs are 'interesting'. There is no obvious heuristic
+      # for this, but having a list of prefixes seems like a good start.
+      ours = False
+      for prefix in prefixes:
+        if PDBPath.startswith(prefix):
+          ours = True
+      if ours:
+        ourModuleCount += 1
         ours = True
-    if ours:
-      ourModuleCount += 1
-      ours = True
-      symFilePath = OrigFileName + "-" + TimeDateStamp + ImageSize + "v1.symcache"
-      symCachePath = symCachePathBase + symFilePath
-      if os.path.isfile(symCachePath):
-        matchExists += 1
-        print( "Copying %s" % symCachePath )
-        shutil.copyfile(symCachePath, DestDirName + "\\" + symFilePath)
+        symFilePath = OrigFileName + "-" + TimeDateStamp + ImageSize + "v1.symcache"
+        symCachePath = symCachePathBase + symFilePath
+        if os.path.isfile(symCachePath):
+          matchExists += 1
+          print("Copying %s" % symCachePath)
+          shutil.copyfile(symCachePath, DestDirName + "\\" + symFilePath)
+        else:
+          print("Symbols for '%s' are not in %s" % (OrigFileName, symCachePathBase))
       else:
-        print( "Symbols for '%s' are not in %s" % (OrigFileName, symCachePathBase) )
-    else:
-      #This is normally too verbose
-      if verbose:
-        print( "Skipping %s" % PDBPath )
+        #This is normally too verbose
+        if verbose:
+          print("Skipping %s" % PDBPath)
 
-print( "%d symbol files found in the trace, %d appear to be ours, and %d of those exist in symcache." % (matchCount, ourModuleCount, matchExists) )
+  print("%d symbol files found in the trace, %d appear to be ours, and %d of those exist in symcache." % (matchCount, ourModuleCount, matchExists))
+
+
+if __name__ == "__main__":
+  main()

--- a/bin/StripChromeSymbols.py
+++ b/bin/StripChromeSymbols.py
@@ -46,38 +46,38 @@ import sys
 import re
 import tempfile
 import shutil
+import subprocess
 
 def main():
-
   if len(sys.argv) < 2:
-    print( "Usage: %s trace.etl" % sys.argv[0] )
+    print("Usage: %s trace.etl" % sys.argv[0])
     sys.exit(0)
 
-  symbolPath = os.environ.get("_NT_SYMBOL_PATH", "")
-  if symbolPath.count("chromium-browser-symsrv") == 0:
-    print( "Chromium symbol server is not in _NT_SYMBOL_PATH. No symbol stripping needed." )
+  symbol_path = os.environ.get("_NT_SYMBOL_PATH", "")
+  if symbol_path.count("chromium-browser-symsrv") == 0:
+    print("Chromium symbol server is not in _NT_SYMBOL_PATH. No symbol stripping needed.")
     sys.exit(0)
 
-  scriptDir = os.path.split(sys.argv[0])[0]
-  retrievePath = os.path.join(scriptDir, "RetrieveSymbols.exe")
-  pdbcopyPath = os.path.join(scriptDir, "pdbcopy.exe")
+  script_dir = os.path.split(sys.argv[0])[0]
+  retrieve_path = os.path.join(script_dir, "RetrieveSymbols.exe")
+  pdbcopy_path = os.path.join(script_dir, "pdbcopy.exe")
 
   # RetrieveSymbols.exe requires some support files. dbghelp.dll and symsrv.dll
   # have to be in the same directory as RetrieveSymbols.exe and pdbcopy.exe must
   # be in the path, so copy them all to the script directory.
   for third_party in ["pdbcopy.exe", "dbghelp.dll", "symsrv.dll"]:
     if not os.path.exists(third_party):
-      source = os.path.normpath(os.path.join(scriptDir, r"..\third_party", \
+      source = os.path.normpath(os.path.join(script_dir, r"..\third_party", \
           third_party))
-      dest = os.path.normpath(os.path.join(scriptDir, third_party))
+      dest = os.path.normpath(os.path.join(script_dir, third_party))
       shutil.copy2(source, dest)
 
-  if not os.path.exists(pdbcopyPath):
-    print( "pdbcopy.exe not found. No symbol stripping is possible." )
+  if not os.path.exists(pdbcopy_path):
+    print("pdbcopy.exe not found. No symbol stripping is possible.")
     sys.exit(0)
 
-  if not os.path.exists(retrievePath):
-    print( "RetrieveSymbols.exe not found. No symbol retrieval is possible." )
+  if not os.path.exists(retrieve_path):
+    print("RetrieveSymbols.exe not found. No symbol retrieval is possible.")
     sys.exit(0)
 
   tracename = sys.argv[1]
@@ -88,90 +88,93 @@ def main():
 
   # Typical output looks like:
   # "[RSDS] PdbSig: {be90dbc6-fe31-4842-9c72-7e2ea88f0adf}; Age: 1; Pdb: C:\b\build\slave\win\build\src\out\Release\syzygy\chrome.dll.pdb"
-  pdbRe = re.compile(r'"\[RSDS\] PdbSig: {(.*-.*-.*-.*-.*)}; Age: (.*); Pdb: (.*)"')
-  pdbCachedRe = re.compile(r"Found .*file - placed it in (.*)")
+  pdb_re = re.compile(r'"\[RSDS\] PdbSig: {(.*-.*-.*-.*-.*)}; Age: (.*); Pdb: (.*)"')
+  pdb_cached_re = re.compile(r"Found .*file - placed it in (.*)")
 
-  print( "Pre-translating chrome symbols from stripped PDBs to avoid 10-15 minute translation times." )
+  print("Pre-translating chrome symbols from stripped PDBs to avoid 10-15 minute translation times.")
 
-  symcacheFiles = []
+  symcache_files = []
   # Keep track of the local symbol files so that we can temporarily rename them
   # to stop xperf from using -- rename them from .pdb to .pdbx
-  localSymbolFiles = []
+  local_symbol_files = []
 
   command = 'xperf -i "%s" -tle -tti -a symcache -dbgid' % tracename
-  print( "> %s" % command )
-  foundUncached = False
-  for line in os.popen(command).readlines():
+  print("> %s" % command)
+  found_uncached = False
+  raw_command_output = subprocess.check_output(command)
+  command_output = str(raw_command_output).splitlines()
+
+  for line in command_output:
     if line.count("chrome.dll") > 0 or line.count("chrome_child.dll") > 0:
-      match = pdbRe.match(line)
+      match = pdb_re.match(line)
       if match:
         guid, age, path = match.groups()
         guid = guid.replace("-", "")
         filepart = os.path.split(path)[1]
-        symcacheFile = r"c:\symcache\chrome.dll-%s%sv2.symcache" % (guid, age)
-        if os.path.exists(symcacheFile):
-          #print "Symcache file %s already exists. Skipping." % symcacheFile
+        symcache_file = r"c:\symcache\chrome.dll-%s%sv2.symcache" % (guid, age)
+        if os.path.exists(symcache_file):
+          #print "Symcache file %s already exists. Skipping." % symcache_file
           continue
         # Only print messages for chrome PDBs that aren't in the symcache
-        foundUncached = True
-        print( "Found uncached reference to %s: %s - %s" % (filepart, guid, age, ) )
-        symcacheFiles.append(symcacheFile)
-        pdbCachePath = None
-        retrieveCommand = "%s %s %s %s" % (retrievePath, guid, age, filepart)
-        print( "> %s" % retrieveCommand )
-        for subline in os.popen(retrieveCommand):
-          print( subline.strip() )
-          cacheMatch = pdbCachedRe.match(subline.strip())
-          if cacheMatch:
-            pdbCachePath = cacheMatch.groups()[0]
-        if not pdbCachePath:
+        found_uncached = True
+        print("Found uncached reference to %s: %s - %s" % (filepart, guid, age, ))
+        symcache_files.append(symcache_file)
+        pdb_cache_path = None
+        retrieve_ommand = "%s %s %s %s" % (retrieve_path, guid, age, filepart)
+        print("> %s" % retrieve_ommand)
+        for subline in os.popen(retrieve_ommand):
+          print(subline.strip())
+          cache_match = pdb_cached_re.match(subline.strip())
+          if cache_match:
+            pdb_cache_path = cache_match.groups()[0]
+        if not pdb_cache_path:
           # Look for locally built symbols
           if os.path.exists(path):
-            pdbCachePath = path
-            localSymbolFiles.append(path)
-        if pdbCachePath:
+            pdb_cache_path = path
+            local_symbol_files.append(path)
+        if pdb_cache_path:
           tempdir = tempfile.mkdtemp()
           tempdirs.append(tempdir)
-          destPath = os.path.join(tempdir, os.path.split(pdbCachePath)[1])
-          print( "Copying PDB to %s" % destPath )
-          for copyline in os.popen("%s %s %s -p" % (pdbcopyPath, pdbCachePath, destPath)):
-            print( copyline.strip() )
+          dest_path = os.path.join(tempdir, os.path.split(pdb_cache_path)[1])
+          print("Copying PDB to %s" % dest_path)
+          for copyline in os.popen("%s %s %s -p" % (pdbcopy_path, pdb_cache_path, dest_path)):
+            print(copyline.strip())
         else:
-          print( "Failed to retrieve symbols. Check for RetrieveSymbols.exe and support files." )
+          print("Failed to retrieve symbols. Check for RetrieveSymbols.exe and support files.")
 
   if tempdirs:
-    symbolPath = ";".join(tempdirs)
-    print( "Stripped PDBs are in %s. Converting to symcache files now." % symbolPath )
-    os.environ["_NT_SYMBOL_PATH"] = symbolPath
-    for localPDB in localSymbolFiles:
-      tempName = localPDB + "x"
-      print( "Renaming %s to %s to stop unstripped PDBs from being used." % (localPDB, tempName) )
-      os.rename(localPDB, tempName)
-    genCommand = 'xperf -i "%s" -symbols -tle -tti -a symcache -build' % tracename
-    print( "> %s" % genCommand )
-    for line in os.popen(genCommand).readlines():
+    symbol_path = ";".join(tempdirs)
+    print("Stripped PDBs are in %s. Converting to symcache files now." % symbol_path)
+    os.environ["_NT_SYMBOL_PATH"] = symbol_path
+    for local_pdb in local_symbol_files:
+      temp_name = local_pdb + "x"
+      print("Renaming %s to %s to stop unstripped PDBs from being used." % (local_pdb, temp_name))
+      os.rename(local_pdb, temp_name)
+    gen_command = 'xperf -i "%s" -symbols -tle -tti -a symcache -build' % tracename
+    print("> %s" % gen_command)
+    for line in os.popen(gen_command).readlines():
       pass # Don't print line
-    for localPDB in localSymbolFiles:
-      tempName = localPDB + "x"
-      os.rename(tempName, localPDB)
+    for local_pdb in local_symbol_files:
+      temp_name = local_pdb + "x"
+      os.rename(temp_name, local_pdb)
     error = False
-    for symcacheFile in symcacheFiles:
-      if os.path.exists(symcacheFile):
-        print( "%s generated." % symcacheFile )
+    for symcache_file in symcache_files:
+      if os.path.exists(symcache_file):
+        print("%s generated." % symcache_file)
       else:
-        print( "Error: %s not generated." % symcacheFile )
+        print("Error: %s not generated." % symcache_file)
         error = True
     # Delete the stripped PDB files
     if error:
-      print( "Retaining PDBs to allow rerunning xperf command-line." )
+      print("Retaining PDBs to allow rerunning xperf command-line.")
     else:
-      for dir in tempdirs:
-        shutil.rmtree(dir, ignore_errors=True)
+      for directory in tempdirs:
+        shutil.rmtree(directory, ignore_errors=True)
   else:
-    if foundUncached:
-      print( "No PDBs copied, nothing to do." )
+    if found_uncached:
+      print("No PDBs copied, nothing to do.")
     else:
-      print( "No uncached PDBS found, nothing to do." )
+      print("No uncached PDBS found, nothing to do.")
 
 if __name__ == "__main__":
-  main( )
+  main()

--- a/bin/XperfProcessParentage.py
+++ b/bin/XperfProcessParentage.py
@@ -13,81 +13,32 @@
 # limitations under the License.
 
 """
-This script uses wpaexporter to export process information from an ETL file
+  This script uses wpaexporter to export process information from an ETL file
 using the techniques described here:
 
 http://randomascii.wordpress.com/2013/11/04/exporting-arbitrary-data-from-xperf-etl-files/
 
 This script relies on having XperfProcessParentage.wpaProfile in the same directory as the script.
 """
+from __future__ import print_function
 
 import os
 import sys
-
-# This is the name of the file that wpaexporter creates when using
-# ProcessParentage.wpaProfile. Ideally this filename could be
-# specified, but oh well.
-csvFilename = "Processes_Summary_Table_ProcessParentage.csv"
-
-if len(sys.argv) < 2:
-  print "Usage: %s trace.etl" % sys.argv[0]
-  print "This script extracts process parentage data from the specified"
-  print "ETL file and prints it in a tree format, together with process name"
-  print "and command line information."
-  print "See this blog post for more details:"
-  print "http://randomascii.wordpress.com/2013/11/04/exporting-arbitrary-data-from-xperf-etl-files/"
-  sys.exit(0)
-
-if not os.path.exists(sys.argv[1]):
-  print "ETL file '%s' does not exist." % sys.argv[1]
-  sys.exit(0)
-
-# Delete any previous results to avoid accidentally using them.
-try:
-  os.remove(csvFilename)
-except WindowsError, e:
-  if e.winerror != 2: # WindowsError: [Error 2] The system cannot find the file specified
-    raise e
-
-# Find the location of the .wpaProfile that is needed for exporting the
-# process parentage data.
-scriptdir = os.path.split(sys.argv[0])[0]
-profilePath = os.path.join(scriptdir, "XperfProcessParentage.wpaProfile")
-
-# Run wpaexporter
-lines = os.popen("wpaexporter \"%s\" -profile \"%s\"" % (sys.argv[1], profilePath)).readlines()
-for line in lines:
-  sys.stderr.write(line)
-
-# Read the raw data.
-lines = open(csvFilename).readlines()
-if len(lines) < 2:
-  print "Missing data. Sorry."
-  sys.exit(0)
+import subprocess
 
 # This dictionary maps from process IDs to their parents
+# It's a fucking global. Fuck!
 parents = {}
+
 # This dictionary maps from process IDs to their details
+# It's a fucking global. Fuck!
 details = {}
+
 # When this is stored in the data field of the parents dictionary
 # it indicates that a process has been printed already.
+# It's a fucking global. Fuck!
 processedParent = -1
 
-# Scan through every line of the .csv file (except the first
-# line which just contains column labels) and fill in the
-# parents and details dictionaries.
-for line in lines[1:]:
-  # Should probably do better CSV parsing, but I don't think it matters.
-  parts = line.strip().split(",")
-  procID = int(parts[0])
-  parentID = int(parts[1])
-  # Treat the remaining fields as a single string.
-  extraData = ",".join(parts[2:])
-  if parents.has_key(procID):
-    sys.stderr.write("Process ID %d found again. Discarding %s\n" % (procID, extraData))
-  else:
-    parents[procID] = parentID
-    details[procID] = extraData
 
 """
 Print a process and recursively print all of its children.
@@ -106,14 +57,14 @@ def PrintProcessTree(procID, indent, bIsLoop):
   loop = ""
   # Look up this process in our database. It might
   # not be there.
-  if details.has_key(procID):
+  if procID in details:
     detail = details[procID]
   else:
     missing = " (missing process)"
   if bIsLoop:
     loop = " (loop)"
   parents[procID] = processedParent
-  print "%s%d%s%s, %s" % ("    " * indent, procID, missing, loop, detail)
+  print("%s%d%s%s, %s" % ("    " * indent, procID, missing, loop, detail))
   # Loop through all of the processes looking for ones that have this
   # process as their parent.
   for childID in parents.keys():
@@ -121,30 +72,98 @@ def PrintProcessTree(procID, indent, bIsLoop):
     if parentID == procID:
       PrintProcessTree(childID, indent+1, False)
 
-# Iterate through all processes. For each process try to find
-# its 'oldest' ancestor, and then print a tree starting from
-# there. Due to PID reuse this will occasionally lead to loops.
-# We detect loops but, unfortunately, they make determining the
-# correct structure impossible, so the code just randomly chooses
-# a point in the loop to print from.
-for procID in parents.keys():
-  if parents[procID] == processedParent:
-    continue
-  # For each one find the 'oldest' ancestor process
-  ultimateParentID = procID
-  count = 0
-  bIsLoop = False
-  # Stop on processes that are their own parents, or processes
-  # whose parents have already been printed.
-  while parents[ultimateParentID] != ultimateParentID and parents[ultimateParentID] != processedParent:
-    # Check for infinite loops. They do happen, presumably when
-    # parent processes go away and their process IDs are reused.
-    count += 1
-    if count > len(parents):
-      bIsLoop = True
-      break
-    ultimateParentID = parents[ultimateParentID]
-    # Stop if the parent is missing.
-    if not parents.has_key(ultimateParentID):
-      break
-  PrintProcessTree(ultimateParentID, 0, bIsLoop)
+def main():
+
+  # This is the name of the file that wpaexporter creates when using
+  # ProcessParentage.wpaProfile. Ideally this filename could be
+  # specified, but oh well.
+  csvFilename = "Processes_Summary_Table_ProcessParentage.csv"
+
+  if len(sys.argv) < 2:
+    print("Usage: %s trace.etl" % sys.argv[0])
+    print("This script extracts process parentage data from the specified")
+    print("ETL file and prints it in a tree format, together with process name")
+    print("and command line information.")
+    print("See this blog post for more details:")
+    print("http://randomascii.wordpress.com/2013/11/04/exporting-arbitrary-data-from-xperf-etl-files/")
+    sys.exit(0)
+
+  if not os.path.exists(sys.argv[1]):
+    print("ETL file '%s' does not exist." % sys.argv[1])
+    sys.exit(0)
+
+  # Delete any previous results to avoid accidentally using them.
+  try:
+    os.remove(csvFilename)
+  except WindowsError as e:
+    if e.winerror != 2: # WindowsError: [Error 2] The system cannot find the file specified
+      raise e
+
+  # Find the location of the .wpaProfile that is needed for exporting the
+  # process parentage data.
+  scriptdir = os.path.split(sys.argv[0])[0]
+  profilePath = os.path.join(scriptdir, "XperfProcessParentage.wpaProfile")
+
+  # Run wpaexporter
+  lines = subprocess.check_output("wpaexporter \"%s\" -profile \"%s\"" % (sys.argv[1], profilePath))
+  for line in lines:
+    print(line, file=sys.stderr)
+
+  
+
+
+
+  # Read the raw data.
+  with open(csvFilename) as csvFile:
+    lines = csvFile.readlines()
+    if len(lines) < 2:
+      print("Missing data. Sorry.")
+      sys.exit(0)
+
+    # Scan through every line of the .csv file (except the first
+    # line which just contains column labels) and fill in the
+    # parents and details dictionaries.
+    for line in lines[1:]:
+      # Should probably do better CSV parsing, but I don't think it matters.
+      parts = line.strip().split(",")
+      procID = int(parts[0])
+      parentID = int(parts[1])
+      # Treat the remaining fields as a single string.
+      extraData = ",".join(parts[2:])
+      if procID in parents:
+        print("Process ID %d found again. Discarding %s\n" % (procID, extraData), file=sys.stderr)
+      else:
+        parents[procID] = parentID
+        details[procID] = extraData
+
+
+  # Iterate through all processes. For each process try to find
+  # its 'oldest' ancestor, and then print a tree starting from
+  # there. Due to PID reuse this will occasionally lead to loops.
+  # We detect loops but, unfortunately, they make determining the
+  # correct structure impossible, so the code just randomly chooses
+  # a point in the loop to print from.
+  for procID in parents.keys():
+    if parents[procID] == processedParent:
+      continue
+    # For each one find the 'oldest' ancestor process
+    ultimateParentID = procID
+    count = 0
+    bIsLoop = False
+    # Stop on processes that are their own parents, or processes
+    # whose parents have already been printed.
+    while parents[ultimateParentID] != ultimateParentID and parents[ultimateParentID] != processedParent:
+      # Check for infinite loops. They do happen, presumably when
+      # parent processes go away and their process IDs are reused.
+      count += 1
+      if count > len(parents):
+        bIsLoop = True
+        break
+      ultimateParentID = parents[ultimateParentID]
+      # Stop if the parent is missing
+      if ultimateParentID not in parents:
+        break
+    PrintProcessTree(ultimateParentID, 0, bIsLoop)
+
+if __name__ == "__main__":
+  main()

--- a/bin/XperfProcessParentage.py
+++ b/bin/XperfProcessParentage.py
@@ -27,16 +27,16 @@ import sys
 import subprocess
 
 # This dictionary maps from process IDs to their parents
-# It's a fucking global. Fuck!
+# TODO: remove global!
 parents = {}
 
 # This dictionary maps from process IDs to their details
-# It's a fucking global. Fuck!
+# TODO: remove global!
 details = {}
 
 # When this is stored in the data field of the parents dictionary
 # it indicates that a process has been printed already.
-# It's a fucking global. Fuck!
+# TODO: remove global!
 processedParent = -1
 
 


### PR DESCRIPTION
I improved [style compliance](https://www.chromium.org/chromium-os/python-style-guidelines) of the Python scripts, and also improved the Python 2.x/3.x cross-compatibility. Running pylint helps!

Removed a few usages of depreciated functions, `os.popen` & `has_key`, and replaced with modern/pythonic alternatives.

For now, I couldn't remove a few globals from XperfProcessParentage.py. Grr.

This should improve readability.