### PR TITLE
Added Windows 8+ mitigations

### DIFF
--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -381,14 +381,14 @@ WindowsVersion GetWindowsVersion()
 	return kWindowsVersionXP;
 }
 
-bool IsWindowsServer()
-{
-	OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, { 0 }, 0, 0, 0, VER_NT_WORKSTATION };
-	DWORDLONG        const dwlConditionMask = VerSetConditionMask(0, VER_PRODUCT_TYPE, VER_EQUAL);
-
-	bool result = !VerifyVersionInfoW(&osvi, VER_PRODUCT_TYPE, dwlConditionMask);
-	return result;
-}
+//bool IsWindowsServer()
+//{
+//	OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, { 0 }, 0, 0, 0, VER_NT_WORKSTATION };
+//	DWORDLONG        const dwlConditionMask = VerSetConditionMask(0, VER_PRODUCT_TYPE, VER_EQUAL);
+//
+//	bool result = !VerifyVersionInfoW(&osvi, VER_PRODUCT_TYPE, dwlConditionMask);
+//	return result;
+//}
 
 
 

--- a/UIforETW/Utility.h
+++ b/UIforETW/Utility.h
@@ -74,7 +74,7 @@ enum WindowsVersion
 
 bool Is64BitWindows();
 WindowsVersion GetWindowsVersion();
-bool IsWindowsServer();
+//bool IsWindowsServer();
 
 std::wstring FindPython(); // Returns a full path to python.exe or nothing.
 

--- a/UIforETW/stdafx.h
+++ b/UIforETW/stdafx.h
@@ -42,6 +42,7 @@ limitations under the License.
 #include <afxcontrolbars.h>     // MFC support for ribbons and control bars
 #include <atlwin.h>
 #include <sal.h>
+#include <VersionHelpers.h>
 
 // Global function for printing to the dialog output window.
 void outputPrintf(_Printf_format_string_ const wchar_t* pFormat, ...);


### PR DESCRIPTION
Microsoft has ["electrified the fences"](http://blogs.msdn.com/b/oldnewthing/archive/2012/05/30/10311557.aspx#10311916) in Windows 8, adding APIs that make it harder to exploit security vulnerabilities.

I've added support for these APIs, especially as UIforETW runs as an elevated process.

I had to comment out `IsWindowsServer( )` in `Utility.h`/`Utility.cpp` because it conflicts with a function of the same name in `VersionHelpers.h`.

I *might* be handling/checking for "impossible" errors, but seeing as these are security-related functions, I think it's imperative that I try to log errors (at LEAST in debug builds).