### PR TITLE
changed `assert`s to `ATLASSERT`s

### DIFF
--- a/UIforETW/ChildProcess.cpp
+++ b/UIforETW/ChildProcess.cpp
@@ -114,7 +114,7 @@ DWORD ChildProcess::ListenerThread()
 _Pre_satisfies_(!(this->hProcess_))
 bool ChildProcess::Run(bool showCommand, std::wstring args)
 {
-	ATLASSERT(!hProcess_);
+	UIETWASSERT(!hProcess_);
 
 	if (showCommand)
 		outputPrintf(L"%s\n", args.c_str());

--- a/UIforETW/ChildProcess.cpp
+++ b/UIforETW/ChildProcess.cpp
@@ -112,10 +112,10 @@ DWORD ChildProcess::ListenerThread()
 	return 0;
 }
 
-
+_Pre_satisfies_(!(this->hProcess_))
 bool ChildProcess::Run(bool showCommand, std::wstring args)
 {
-	assert(!hProcess_);
+	ATLASSERT(!hProcess_);
 
 	if (showCommand)
 		outputPrintf(L"%s\n", args.c_str());

--- a/UIforETW/ChildProcess.cpp
+++ b/UIforETW/ChildProcess.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 #include "ChildProcess.h"
 #include "Utility.h"
 
-#include <assert.h>
 #include <vector>
 
 static const wchar_t* kPipeName = L"\\\\.\\PIPE\\UIforETWPipe";

--- a/UIforETW/ChildProcess.h
+++ b/UIforETW/ChildProcess.h
@@ -37,6 +37,7 @@ public:
 	~ChildProcess();
 
 	// Returns true if the process started.
+	_Pre_satisfies_(!(this->hProcess_))
 	bool Run(bool showCommand, std::wstring args);
 
 	// This can be called even if the process doesn't start, but

--- a/UIforETW/DirectoryMonitor.cpp
+++ b/UIforETW/DirectoryMonitor.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 
 #include "stdafx.h"
 #include "DirectoryMonitor.h"
-#include <assert.h>
 
 DirectoryMonitor::DirectoryMonitor(CWnd* pMainWindow)
 	: mainWindow_(pMainWindow)

--- a/UIforETW/DirectoryMonitor.cpp
+++ b/UIforETW/DirectoryMonitor.cpp
@@ -37,7 +37,7 @@ DWORD DirectoryMonitor::DirectoryMonitorThread()
 
 	if (hChangeHandle == INVALID_HANDLE_VALUE)
 	{
-		ATLASSERT(0);
+		UIETWASSERT(0);
 		return 0;
 	}
 
@@ -52,7 +52,7 @@ DWORD DirectoryMonitor::DirectoryMonitorThread()
 			mainWindow_->PostMessage(WM_UPDATETRACELIST, 0, 0);
 			if (FindNextChangeNotification(hChangeHandle) == FALSE)
 			{
-				ATLASSERT(0);
+				UIETWASSERT(0);
 				return 0;
 			}
 			break;
@@ -61,7 +61,7 @@ DWORD DirectoryMonitor::DirectoryMonitorThread()
 			return 0;
 
 		default:
-			ATLASSERT(0);
+			UIETWASSERT(0);
 			break;
 		}
 	}
@@ -72,8 +72,8 @@ _Pre_satisfies_(this->hThread_ == 0)
 _Pre_satisfies_(this->hShutdownRequest_ == 0)
 void DirectoryMonitor::StartThread(const std::wstring* traceDir)
 {
-	ATLASSERT(hThread_ == 0);
-	ATLASSERT(hShutdownRequest_ == 0);
+	UIETWASSERT(hThread_ == 0);
+	UIETWASSERT(hShutdownRequest_ == 0);
 	traceDir_ = traceDir;
 	// No error checking -- what could go wrong?
 	hThread_ = CreateThread(nullptr, 0, DirectoryMonitorThreadStatic, this, 0, 0);

--- a/UIforETW/DirectoryMonitor.cpp
+++ b/UIforETW/DirectoryMonitor.cpp
@@ -38,7 +38,7 @@ DWORD DirectoryMonitor::DirectoryMonitorThread()
 
 	if (hChangeHandle == INVALID_HANDLE_VALUE)
 	{
-		assert(0);
+		ATLASSERT(0);
 		return 0;
 	}
 
@@ -53,7 +53,7 @@ DWORD DirectoryMonitor::DirectoryMonitorThread()
 			mainWindow_->PostMessage(WM_UPDATETRACELIST, 0, 0);
 			if (FindNextChangeNotification(hChangeHandle) == FALSE)
 			{
-				assert(0);
+				ATLASSERT(0);
 				return 0;
 			}
 			break;
@@ -62,21 +62,23 @@ DWORD DirectoryMonitor::DirectoryMonitorThread()
 			return 0;
 
 		default:
-			assert(0);
+			ATLASSERT(0);
 			break;
 		}
 	}
   // Unreachable.
 }
 
+_Pre_satisfies_(this->hThread_ == 0)
+_Pre_satisfies_(this->hShutdownRequest_ == 0)
 void DirectoryMonitor::StartThread(const std::wstring* traceDir)
 {
-	assert(hThread_ == 0);
-	assert(hShutdownRequest_ == 0);
+	ATLASSERT(hThread_ == 0);
+	ATLASSERT(hShutdownRequest_ == 0);
 	traceDir_ = traceDir;
 	// No error checking -- what could go wrong?
 	hThread_ = CreateThread(nullptr, 0, DirectoryMonitorThreadStatic, this, 0, 0);
-	hShutdownRequest_ = CreateEvent(nullptr, FALSE, FALSE, nullptr);;
+	hShutdownRequest_ = CreateEvent(nullptr, FALSE, FALSE, nullptr);
 }
 
 DirectoryMonitor::~DirectoryMonitor()

--- a/UIforETW/DirectoryMonitor.h
+++ b/UIforETW/DirectoryMonitor.h
@@ -24,6 +24,9 @@ public:
 	DirectoryMonitor(CWnd* pMainWindow);
 	~DirectoryMonitor();
 
+
+	_Pre_satisfies_(this->hThread_ == 0)
+	_Pre_satisfies_(this->hShutdownRequest_ == 0)
 	void StartThread(const std::wstring* traceDir);
 
 private:

--- a/UIforETW/KeyLoggerThread.cpp
+++ b/UIforETW/KeyLoggerThread.cpp
@@ -27,7 +27,7 @@ std::atomic<bool> g_LogKeyboardDetails = false;
 
 LRESULT CALLBACK LowLevelKeyboardHook(int nCode, WPARAM wParam, LPARAM lParam)
 {
-	assert(nCode == HC_ACTION);
+	ATLASSERT(nCode == HC_ACTION);
 	// wParam is WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, or WM_SYSKEYUP
 
 	KBDLLHOOKSTRUCT* pKbdLLHook = (KBDLLHOOKSTRUCT*)lParam;

--- a/UIforETW/KeyLoggerThread.cpp
+++ b/UIforETW/KeyLoggerThread.cpp
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 #include "stdafx.h"
-#include <assert.h>
 #include "KeyLoggerThread.h"
 #include <ETWProviders\etwprof.h>
 #include <atomic>
@@ -126,7 +125,7 @@ LRESULT CALLBACK LowLevelKeyboardHook(int nCode, WPARAM wParam, LPARAM lParam)
 
 LRESULT CALLBACK LowLevelMouseHook(int nCode, WPARAM wParam, LPARAM lParam)
 {
-	assert(nCode == HC_ACTION);
+	ATLASSERT(nCode == HC_ACTION);
 
 	MSLLHOOKSTRUCT* pMouseLLHook = (MSLLHOOKSTRUCT*)lParam;
 

--- a/UIforETW/KeyLoggerThread.cpp
+++ b/UIforETW/KeyLoggerThread.cpp
@@ -24,9 +24,10 @@ namespace
 
 std::atomic<bool> g_LogKeyboardDetails = false;
 
+_Pre_satisfies_(nCode == HC_ACTION)
 LRESULT CALLBACK LowLevelKeyboardHook(int nCode, WPARAM wParam, LPARAM lParam)
 {
-	ATLASSERT(nCode == HC_ACTION);
+	UIETWASSERT(nCode == HC_ACTION);
 	// wParam is WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, or WM_SYSKEYUP
 
 	KBDLLHOOKSTRUCT* pKbdLLHook = (KBDLLHOOKSTRUCT*)lParam;
@@ -123,9 +124,10 @@ LRESULT CALLBACK LowLevelKeyboardHook(int nCode, WPARAM wParam, LPARAM lParam)
 	return CallNextHookEx(0, nCode, wParam, lParam);
 }
 
+_Pre_satisfies_(nCode == HC_ACTION)
 LRESULT CALLBACK LowLevelMouseHook(int nCode, WPARAM wParam, LPARAM lParam)
 {
-	ATLASSERT(nCode == HC_ACTION);
+	UIETWASSERT(nCode == HC_ACTION);
 
 	MSLLHOOKSTRUCT* pMouseLLHook = (MSLLHOOKSTRUCT*)lParam;
 

--- a/UIforETW/Settings.cpp
+++ b/UIforETW/Settings.cpp
@@ -145,7 +145,7 @@ void CSettings::OnBnClickedCopystartupprofile()
 	wchar_t documents[MAX_PATH];
 
 	const BOOL getMyDocsResult = SHGetSpecialFolderPathW(m_hWnd, documents, CSIDL_MYDOCUMENTS, TRUE);
-	ATLASSERT(getMyDocsResult);
+	UIETWASSERT(getMyDocsResult);
 	if (!getMyDocsResult)
 	{
 		OutputDebugStringA("Failed to find My Documents directory.\r\n");

--- a/UIforETW/Settings.cpp
+++ b/UIforETW/Settings.cpp
@@ -143,11 +143,15 @@ void CSettings::OnBnClickedCopystartupprofile()
 	std::wstring source = exeDir_ + fileName;
 
 	wchar_t documents[MAX_PATH];
-	if (!SHGetSpecialFolderPath(*this, documents, CSIDL_MYDOCUMENTS, TRUE))
+
+	const BOOL getMyDocsResult = SHGetSpecialFolderPathW(m_hWnd, documents, CSIDL_MYDOCUMENTS, TRUE);
+	ATLASSERT(getMyDocsResult);
+	if (!getMyDocsResult)
 	{
-		assert(!"Failed to find My Documents directory.\n");
+		OutputDebugStringA("Failed to find My Documents directory.\r\n");
 		return;
 	}
+
 	std::wstring dest = documents + std::wstring(L"\\WPA Files\\") + fileName;
 	if (CopyFile(source.c_str(), dest.c_str(), FALSE))
 	{

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -271,16 +271,16 @@ BOOL CUIforETWDlg::OnInitDialog()
 	// Add "About..." menu item to system menu.
 
 	// IDM_ABOUTBOX must be in the system command range.
-	ASSERT((IDM_ABOUTBOX & 0xFFF0) == IDM_ABOUTBOX);
-	ASSERT(IDM_ABOUTBOX < 0xF000);
+	ATLASSERT((IDM_ABOUTBOX & 0xFFF0) == IDM_ABOUTBOX);
+	ATLASSERT(IDM_ABOUTBOX < 0xF000);
 
 	CMenu* pSysMenu = GetSystemMenu(FALSE);
 	if (pSysMenu)
 	{
-		BOOL bNameValid;
+		//BOOL bNameValid;
 		CString strAboutMenu;
-		bNameValid = strAboutMenu.LoadString(IDS_ABOUTBOX);
-		ASSERT(bNameValid);
+		const BOOL bNameValid = strAboutMenu.LoadString(IDS_ABOUTBOX);
+		ATLASSERT(bNameValid);
 		if (!strAboutMenu.IsEmpty())
 		{
 			pSysMenu->AppendMenu(MF_SEPARATOR);
@@ -295,7 +295,7 @@ BOOL CUIforETWDlg::OnInitDialog()
 	}
 
 	wchar_t* windowsDir = nullptr;
-	VERIFY(SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Windows, 0, NULL, &windowsDir)));
+	ATLVERIFY(SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Windows, 0, NULL, &windowsDir)));
 	windowsDir_ = windowsDir;
 	windowsDir_ += '\\';
 	CoTaskMemFree(windowsDir);
@@ -322,9 +322,11 @@ BOOL CUIforETWDlg::OnInitDialog()
 	}
 
 	wchar_t documents[MAX_PATH];
-	if (!SHGetSpecialFolderPath(*this, documents, CSIDL_MYDOCUMENTS, TRUE))
+	const BOOL getMyDocsResult = SHGetSpecialFolderPath(*this, documents, CSIDL_MYDOCUMENTS, TRUE);
+	ATLASSERT(getMyDocsResult);
+	if (!getMyDocsResult)
 	{
-		assert(!"Failed to find My Documents directory.\n");
+		OutputDebugStringA("Failed to find My Documents directory.\r\n");
 		exit(10);
 	}
 	std::wstring defaultTraceDir = documents + std::wstring(L"\\etwtraces\\");
@@ -675,7 +677,7 @@ void CUIforETWDlg::OnBnClickedStarttracing()
 	else if (tracingMode_ == kHeapTracingToFile)
 		outputPrintf(L"\nStarting heap tracing to disk of %s...\n", heapTracingExes_.c_str());
 	else
-		assert(0);
+		ATLASSERT(0);
 
 	std::wstring kernelProviders = L" Latency+POWER+DISPATCHER+FILE_IO+FILE_IO_INIT+VIRT_ALLOC+MEMINFO";
 	std::wstring kernelStackWalk;
@@ -1043,7 +1045,7 @@ void CUIforETWDlg::OnCbnSelchangeInputtracing()
 		outputPrintf(L"Key logging enabled. Full keyboard information recorded - beware of private information being recorded.\n");
 		break;
 	default:
-		assert(0);
+		ATLASSERT(0);
 		InputTracing_ = kKeyLoggerOff;
 		break;
 	}

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -1044,7 +1044,7 @@ void CUIforETWDlg::OnCbnSelchangeInputtracing()
 		outputPrintf(L"Key logging enabled. Full keyboard information recorded - beware of private information being recorded.\n");
 		break;
 	default:
-		ATLASSERT(0);
+		UIETWASSERT(0);
 		InputTracing_ = kKeyLoggerOff;
 		break;
 	}

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -271,16 +271,15 @@ BOOL CUIforETWDlg::OnInitDialog()
 	// Add "About..." menu item to system menu.
 
 	// IDM_ABOUTBOX must be in the system command range.
-	ATLASSERT((IDM_ABOUTBOX & 0xFFF0) == IDM_ABOUTBOX);
-	ATLASSERT(IDM_ABOUTBOX < 0xF000);
+	UIETWASSERT((IDM_ABOUTBOX & 0xFFF0) == IDM_ABOUTBOX);
+	UIETWASSERT(IDM_ABOUTBOX < 0xF000);
 
 	CMenu* pSysMenu = GetSystemMenu(FALSE);
 	if (pSysMenu)
 	{
-		//BOOL bNameValid;
 		CString strAboutMenu;
 		const BOOL bNameValid = strAboutMenu.LoadString(IDS_ABOUTBOX);
-		ATLASSERT(bNameValid);
+		UIETWASSERT(bNameValid);
 		if (!strAboutMenu.IsEmpty())
 		{
 			pSysMenu->AppendMenu(MF_SEPARATOR);
@@ -323,7 +322,7 @@ BOOL CUIforETWDlg::OnInitDialog()
 
 	wchar_t documents[MAX_PATH];
 	const BOOL getMyDocsResult = SHGetSpecialFolderPath(*this, documents, CSIDL_MYDOCUMENTS, TRUE);
-	ATLASSERT(getMyDocsResult);
+	UIETWASSERT(getMyDocsResult);
 	if (!getMyDocsResult)
 	{
 		OutputDebugStringA("Failed to find My Documents directory.\r\n");
@@ -677,7 +676,7 @@ void CUIforETWDlg::OnBnClickedStarttracing()
 	else if (tracingMode_ == kHeapTracingToFile)
 		outputPrintf(L"\nStarting heap tracing to disk of %s...\n", heapTracingExes_.c_str());
 	else
-		ATLASSERT(0);
+		UIETWASSERT(0);
 
 	std::wstring kernelProviders = L" Latency+POWER+DISPATCHER+FILE_IO+FILE_IO_INIT+VIRT_ALLOC+MEMINFO";
 	std::wstring kernelStackWalk;

--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -201,13 +201,14 @@ static HWND GetNextDlgItem(HWND win, bool Wrap)
 				return 0;
 		}
 	}
-	assert(!Wrap || next);
+	ATLASSERT(!Wrap || next);
 	return next;
 }
 
+_Pre_satisfies_(Win)
 void SmartEnableWindow(HWND Win, BOOL Enable)
 {
-	assert(Win);
+	ATLASSERT(Win);
 	if (!Enable)
 	{
 		HWND hasfocus = GetFocus();

--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -201,14 +201,14 @@ static HWND GetNextDlgItem(HWND win, bool Wrap)
 				return 0;
 		}
 	}
-	ATLASSERT(!Wrap || next);
+	UIETWASSERT(!Wrap || next);
 	return next;
 }
 
 _Pre_satisfies_(Win)
 void SmartEnableWindow(HWND Win, BOOL Enable)
 {
-	ATLASSERT(Win);
+	UIETWASSERT(Win);
 	if (!Enable)
 	{
 		HWND hasfocus = GetFocus();

--- a/UIforETW/Utility.h
+++ b/UIforETW/Utility.h
@@ -35,9 +35,11 @@ void CreateRegistryKey(HKEY root, const std::wstring& subkey, const std::wstring
 
 std::wstring GetEditControlText(HWND hwnd);
 std::wstring AnsiToUnicode(const std::string& text);
+
 // This function checks to see whether a control has focus before
 // disabling it. If it does have focus then it moves the focus, to
 // avoid breaking keyboard mnemonics.
+_Pre_satisfies_(Win)
 void SmartEnableWindow(HWND Win, BOOL Enable);
 
 // Return the string after the final '\' or after the final '.' in

--- a/UIforETW/WorkingSet.cpp
+++ b/UIforETW/WorkingSet.cpp
@@ -111,7 +111,7 @@ void CWorkingSetMonitor::SampleWorkingSets()
 						}
 						else
 						{
-							assert(pwsBuffer->WorkingSetInfo[page].ShareCount <= 7);
+							ATLASSERT(pwsBuffer->WorkingSetInfo[page].ShareCount <= 7);
 							PSSPages += PSSMultiplier / pwsBuffer->WorkingSetInfo[page].ShareCount;
 						}
 					}

--- a/UIforETW/WorkingSet.cpp
+++ b/UIforETW/WorkingSet.cpp
@@ -111,7 +111,7 @@ void CWorkingSetMonitor::SampleWorkingSets()
 						}
 						else
 						{
-							ATLASSERT(pwsBuffer->WorkingSetInfo[page].ShareCount <= 7);
+							UIETWASSERT(pwsBuffer->WorkingSetInfo[page].ShareCount <= 7);
 							PSSPages += PSSMultiplier / pwsBuffer->WorkingSetInfo[page].ShareCount;
 						}
 					}

--- a/UIforETW/stdafx.h
+++ b/UIforETW/stdafx.h
@@ -57,6 +57,9 @@ void outputPrintf(_Printf_format_string_ const wchar_t* pFormat, ...);
 const int WM_UPDATETRACELIST = WM_USER + 10;
 
 
+#define UIETWASSERT( x ) ATLASSERT( x )
+
+
 #ifdef _UNICODE
 #if defined _M_IX86
 #pragma comment(linker,"/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='x86' publicKeyToken='6595b64144ccf1df' language='*'\"")

--- a/UIforETW/stdafx.h
+++ b/UIforETW/stdafx.h
@@ -33,7 +33,6 @@ limitations under the License.
 #define _AFX_ALL_WARNINGS
 
 #include <afxext.h>         // MFC extensions
-#include <assert.h>
 
 #ifndef _AFX_NO_AFXCMN_SUPPORT
 #include <afxcmn.h>             // MFC support for Windows Common Controls


### PR DESCRIPTION
I also inserted `_Pre_satisfies_` annotations for function and object/member function preconditions.

In `Settings.cpp`, I changed an implicit conversion of `*CSettings`/`*this` to `HWND` (via `CWnd::operator HWND`) to explicitly passing m_hWnd.


`ATLASSERT` calls `_CrtDbgBreak` instead of `abort`, and is generally suited better to UI programming.