### PR TITLE
add reserve, swap push_back with emplace_back

### DIFF
--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -1646,7 +1646,7 @@ void CUIforETWDlg::PreprocessTrace(const std::wstring& traceFilename)
 		child.Run(bShowCommands_, L"xperf.exe" + args);
 		std::wstring output = child.GetOutput();
 		std::map<std::wstring, std::vector<DWORD>> pidsByType;
-		for (const auto line : split(output, '\n'))
+		for (const auto& line : split(output, '\n'))
 		{
 			if (wcsstr(line.c_str(), L"chrome.exe"))
 			{

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -1388,7 +1388,7 @@ void CUIforETWDlg::OnContextMenu(CWnd* pWnd, CPoint point)
 				ID_TRACES_TRACEPATHTOCLIPBOARD,
 			};
 
-			for (auto id : disableList)
+			for (const auto& id : disableList)
 				pContextMenu->EnableMenuItem(id, MF_BYCOMMAND | MF_GRAYED);
 		}
 
@@ -1569,7 +1569,7 @@ void CUIforETWDlg::CompressAllTraces() const
 	int64_t finalTotalSize = 0;
 	int notCompressedCount = 0;
 	int compressedCount = 0;
-	for (auto traceName : traces_)
+	for (const auto& traceName : traces_)
 	{
 		auto result = CompressTrace(GetTraceDir() + traceName + L".etl");
 		if (result.first == result.second)
@@ -1646,7 +1646,7 @@ void CUIforETWDlg::PreprocessTrace(const std::wstring& traceFilename)
 		child.Run(bShowCommands_, L"xperf.exe" + args);
 		std::wstring output = child.GetOutput();
 		std::map<std::wstring, std::vector<DWORD>> pidsByType;
-		for (auto& line : split(output, '\n'))
+		for (const auto line : split(output, '\n'))
 		{
 			if (wcsstr(line.c_str(), L"chrome.exe"))
 			{
@@ -1670,7 +1670,7 @@ void CUIforETWDlg::PreprocessTrace(const std::wstring& traceFilename)
 				}
 				if (pid)
 				{
-					pidsByType[type].push_back(pid);
+					pidsByType[type].emplace_back(pid);
 				}
 			}
 		}
@@ -1679,10 +1679,10 @@ void CUIforETWDlg::PreprocessTrace(const std::wstring& traceFilename)
 		if (pFile)
 		{
 			fwprintf(pFile, L"Chrome PIDs by process type:\n");
-			for (auto& types : pidsByType)
+			for (const auto& types : pidsByType)
 			{
 				fwprintf(pFile, L"%-10s:", types.first.c_str());
-				for (auto& pid : types.second)
+				for (const auto& pid : types.second)
 				{
 					fwprintf(pFile, L" %lu", pid);
 				}
@@ -1773,10 +1773,11 @@ void CUIforETWDlg::FinishTraceRename()
 	{
 		auto oldNames = GetFileList(GetTraceDir() + preRenameTraceName_ + L".*");
 		std::vector<std::pair<std::wstring, std::wstring>> renamed;
+		renamed.reserve(oldNames.size());
 		std::wstring failedSource;
-		for (auto oldName : oldNames)
+		for (const auto& oldName : oldNames)
 		{
-			std::wstring extension = GetFileExt(oldName);;
+			std::wstring extension = GetFileExt(oldName);
 			std::wstring newName = newTraceName + extension;
 			BOOL result = MoveFile((GetTraceDir() + oldName).c_str(), (GetTraceDir() + newName).c_str());
 			if (!result)
@@ -1784,7 +1785,7 @@ void CUIforETWDlg::FinishTraceRename()
 				failedSource = oldName;
 				break;
 			}
-			renamed.push_back(std::pair<std::wstring, std::wstring>(oldName, newName));
+			renamed.emplace_back(std::make_pair(oldName, newName));
 		}
 		// If any of the renaming steps fail then undo the renames that
 		// succeeded. This should usually fail. If not, there isn't much that
@@ -1798,7 +1799,7 @@ void CUIforETWDlg::FinishTraceRename()
 		}
 		else
 		{
-			for (auto& renamePair : renamed)
+			for (const auto& renamePair : renamed)
 			{
 				(void)MoveFile((GetTraceDir() + renamePair.second).c_str(), (GetTraceDir() + renamePair.first).c_str());
 			}

--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -24,15 +24,16 @@ std::vector<std::wstring> split(const std::wstring& s, char c)
 	std::wstring::size_type j = s.find(c);
 
 	std::vector<std::wstring> result;
+	result.reserve(s.length());
 	while (j != std::wstring::npos)
 	{
-		result.push_back(s.substr(i, j - i));
+		result.emplace_back(s.substr(i, j - i));
 		i = ++j;
 		j = s.find(c, j);
 	}
 
 	if (!s.empty())
-		result.push_back(s.substr(i, s.length()));
+		result.emplace_back(s.substr(i, s.length()));
 
 	return result;
 }
@@ -51,7 +52,7 @@ std::vector<std::wstring> GetFileList(const std::wstring& pattern, bool fullPath
 	{
 		do
 		{
-			result.push_back(directory + findData.cFileName);
+			result.emplace_back(directory + findData.cFileName);
 		} while (FindNextFile(hFindFile, &findData));
 
 		FindClose(hFindFile);
@@ -274,22 +275,31 @@ std::wstring StripExtensionFromPath(const std::wstring& path)
 int DeleteOneFile(HWND hwnd, const std::wstring& path)
 {
 	std::vector<std::wstring> paths;
-	paths.push_back(path);
+	paths.emplace_back(path);
 	return DeleteFiles(hwnd, paths);
 }
 
 int DeleteFiles(HWND hwnd, const std::vector<std::wstring>& paths)
 {
+	ATLASSERT(paths.size() > 0);
+
+	size_t totalLength = 1;
+	for (const auto& path : paths)
+	{
+		totalLength += (path.length() + 1);
+	}
+
 	std::vector<wchar_t> fileNames;
-	for (auto& path : paths)
+	fileNames.reserve(totalLength);
+	for (const auto& path : paths)
 	{
 		// Push the file name and its NULL terminator onto the vector.
 		fileNames.insert(fileNames.end(), path.c_str(), path.c_str() + path.size());
-		fileNames.push_back(0);
+		fileNames.emplace_back(0);
 	}
 
 	// Double null-terminate.
-	fileNames.push_back(0);
+	fileNames.emplace_back(0);
 
 	SHFILEOPSTRUCT fileOp =
 	{
@@ -417,7 +427,7 @@ std::wstring FindPython()
 	if (path)
 	{
 		std::vector<std::wstring> pathParts = split(path, ';');
-		for (auto part : pathParts)
+		for (const auto& part : pathParts)
 		{
 			std::wstring pythonPath = part + L"\\python.exe";
 			if (PathFileExists(pythonPath.c_str()))

--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -283,14 +283,7 @@ int DeleteFiles(HWND hwnd, const std::vector<std::wstring>& paths)
 {
 	ATLASSERT(paths.size() > 0);
 
-	size_t totalLength = 1;
-	for (const auto& path : paths)
-	{
-		totalLength += (path.length() + 1);
-	}
-
 	std::vector<wchar_t> fileNames;
-	fileNames.reserve(totalLength);
 	for (const auto& path : paths)
 	{
 		// Push the file name and its NULL terminator onto the vector.


### PR DESCRIPTION
In places where we'd fill a `std::vector` inside a for loop, I added a call to `reserve` to preallocate the necessary space.

I replaced `push_back` with `emplace_back`, saving silly copy constructions.

In ranged-for loops, I changed `auto` to `auto&` to avoid copies, and added const wherever the items are not modified.