### PR TITLE
Fix annoying warnings

### DIFF
--- a/UIforETW/Settings.cpp
+++ b/UIforETW/Settings.cpp
@@ -144,7 +144,7 @@ void CSettings::OnBnClickedCopystartupprofile()
 
 	wchar_t documents[MAX_PATH];
 
-	const BOOL getMyDocsResult = SHGetSpecialFolderPathW(m_hWnd, documents, CSIDL_MYDOCUMENTS, TRUE);
+	const BOOL getMyDocsResult = SHGetSpecialFolderPathW(NULL, documents, CSIDL_MYDOCUMENTS, TRUE);
 	UIETWASSERT(getMyDocsResult);
 	if (!getMyDocsResult)
 	{

--- a/UIforETW/UIforETW.vcxproj
+++ b/UIforETW/UIforETW.vcxproj
@@ -178,7 +178,6 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <EnablePREfast>false</EnablePREfast>
-      <AdditionalOptions> /Qvec-report:2</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -216,7 +215,6 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <EnablePREfast>false</EnablePREfast>
-      <AdditionalOptions> /Qvec-report:2</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/UIforETW/UIforETW.vcxproj
+++ b/UIforETW/UIforETW.vcxproj
@@ -178,6 +178,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <EnablePREfast>false</EnablePREfast>
+      <AdditionalOptions> /Qvec-report:2</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -215,6 +216,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <EnablePREfast>false</EnablePREfast>
+      <AdditionalOptions> /Qvec-report:2</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -355,7 +355,7 @@ BOOL CUIforETWDlg::OnInitDialog()
 	if (winver <= kWindowsVersion7)
 	{
 		bCompress_ = false; // ETW trace compression requires Windows 8.0
-		SmartEnableWindow(btCompress_, false);
+		SmartEnableWindow(btCompress_.m_hWnd, false);
 	}
 
 	CheckDlgButton(IDC_COMPRESSTRACE, bCompress_);
@@ -550,14 +550,14 @@ void CUIforETWDlg::DisablePagingExecutive()
 
 void CUIforETWDlg::UpdateEnabling()
 {
-	SmartEnableWindow(btStartTracing_, !bIsTracing_);
-	SmartEnableWindow(btSaveTraceBuffers_, bIsTracing_);
-	SmartEnableWindow(btStopTracing_, bIsTracing_);
-	SmartEnableWindow(btTracingMode_, !bIsTracing_);
+	SmartEnableWindow(btStartTracing_.m_hWnd, !bIsTracing_);
+	SmartEnableWindow(btSaveTraceBuffers_.m_hWnd, bIsTracing_);
+	SmartEnableWindow(btStopTracing_.m_hWnd, bIsTracing_);
+	SmartEnableWindow(btTracingMode_.m_hWnd, !bIsTracing_);
 
-	SmartEnableWindow(btSampledStacks_, !bIsTracing_);
-	SmartEnableWindow(btCswitchStacks_, !bIsTracing_);
-	SmartEnableWindow(btGPUTracing_, !bIsTracing_);
+	SmartEnableWindow(btSampledStacks_.m_hWnd, !bIsTracing_);
+	SmartEnableWindow(btCswitchStacks_.m_hWnd, !bIsTracing_);
+	SmartEnableWindow(btGPUTracing_.m_hWnd, !bIsTracing_);
 }
 
 void CUIforETWDlg::OnSysCommand(UINT nID, LPARAM lParam)
@@ -1197,7 +1197,7 @@ void CUIforETWDlg::UpdateNotesState()
 	int curSel = btTraces_.GetCurSel();
 	if (curSel >= 0 && curSel < (int)traces_.size())
 	{
-		SmartEnableWindow(btTraceNotes_, true);
+		SmartEnableWindow(btTraceNotes_.m_hWnd, true);
 		std::wstring traceName = traces_[curSel];
 		traceNoteFilename_ = GetTraceDir() + traceName + L".txt";
 		traceNotes_ = LoadFileAsText(traceNoteFilename_);
@@ -1205,7 +1205,7 @@ void CUIforETWDlg::UpdateNotesState()
 	}
 	else
 	{
-		SmartEnableWindow(btTraceNotes_, false);
+		SmartEnableWindow(btTraceNotes_.m_hWnd, false);
 		SetDlgItemText(IDC_TRACENOTES, L"");
 	}
 }

--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -205,7 +205,7 @@ static HWND GetNextDlgItem(HWND win, bool Wrap)
 	return next;
 }
 
-_Pre_satisfies_(Win)
+_Pre_satisfies_(Win != NULL)
 void SmartEnableWindow(HWND Win, BOOL Enable)
 {
 	UIETWASSERT(Win);

--- a/UIforETW/Utility.h
+++ b/UIforETW/Utility.h
@@ -39,7 +39,7 @@ std::wstring AnsiToUnicode(const std::string& text);
 // This function checks to see whether a control has focus before
 // disabling it. If it does have focus then it moves the focus, to
 // avoid breaking keyboard mnemonics.
-_Pre_satisfies_(Win)
+_Pre_satisfies_(Win != NULL)
 void SmartEnableWindow(HWND Win, BOOL Enable);
 
 // Return the string after the final '\' or after the final '.' in


### PR DESCRIPTION
I also made the implicit `operator HWND` conversions in calls to `SmartEnableWindow`, to explicit `.m_hWnd` access.