### PR TITLE
ETWProviders cleanup

### DIFF
--- a/ETWProviders/ETWProviders.vcxproj
+++ b/ETWProviders/ETWProviders.vcxproj
@@ -69,20 +69,28 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)..\bin\</OutDir>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <TargetName>$(ProjectName)64</TargetName>
     <OutDir>$(SolutionDir)..\bin\</OutDir>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)..\bin\</OutDir>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <TargetName>$(ProjectName)64</TargetName>
     <OutDir>$(SolutionDir)..\bin\</OutDir>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -91,6 +99,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;_DEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
+      <EnablePREfast>true</EnablePREfast>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -111,6 +120,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;_DEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
+      <EnablePREfast>true</EnablePREfast>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -134,6 +144,7 @@
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;NDEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <EnablePREfast>true</EnablePREfast>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -161,6 +172,7 @@
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;NDEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalOptions> /Qvec-report:2</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/ETWProviders/ETWProviders.vcxproj
+++ b/ETWProviders/ETWProviders.vcxproj
@@ -95,7 +95,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;_DEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
@@ -116,7 +116,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;_DEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
@@ -136,7 +136,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -164,7 +164,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -172,7 +172,6 @@
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;NDEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalOptions> /Qvec-report:2</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/ETWProviders/ETWProviders.vcxproj
+++ b/ETWProviders/ETWProviders.vcxproj
@@ -100,6 +100,9 @@
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;_DEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <EnablePREfast>true</EnablePREfast>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <SDLCheck>true</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -121,6 +124,9 @@
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;_DEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <EnablePREfast>true</EnablePREfast>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <SDLCheck>true</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -145,6 +151,9 @@
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <EnablePREfast>true</EnablePREfast>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <SDLCheck>true</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -172,6 +181,9 @@
       <PreprocessorDefinitions>ETWPROVIDERSDLL;WIN32;NDEBUG;_WINDOWS;_USRDLL;ETWPROVIDERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <SDLCheck>true</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/ETWProviders/dllmain.cpp
+++ b/ETWProviders/dllmain.cpp
@@ -16,9 +16,9 @@ limitations under the License.
 
 #include "stdafx.h"
 
-BOOL APIENTRY DllMain( HMODULE hModule,
+BOOL APIENTRY DllMain( HMODULE /*hModule*/,
                        DWORD  ul_reason_for_call,
-                       LPVOID lpReserved
+                       LPVOID /*lpReserved*/
 					 )
 {
 	switch (ul_reason_for_call)

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -137,7 +137,7 @@ ULONG EVNTAPI EventWrite( _In_ REGHANDLE RegHandle, _In_ PCEVENT_DESCRIPTOR Even
 }
 
 // Redirector function for EventUnregister. Called by macros in ETWProviderGenerated.h
-ULONG EVNTAPI EventUnregister( REGHANDLE RegHandle )
+ULONG EVNTAPI EventUnregister( _In_ REGHANDLE RegHandle )
 {
 	if ( g_ETWRegister.m_pEventUnregister )
 		return g_ETWRegister.m_pEventUnregister( RegHandle );

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -120,6 +120,7 @@ public:
 } g_ETWRegister;
 
 // Redirector function for EventRegister. Called by macros in ETWProviderGenerated.h
+_Success_(return == ERROR_SUCCESS)
 ULONG EVNTAPI EventRegister( _In_ LPCGUID ProviderId, _In_opt_ PENABLECALLBACK EnableCallback, _In_opt_ PVOID CallbackContext, _Out_ PREGHANDLE RegHandle )
 {
 	if ( g_ETWRegister.m_pEventRegister )
@@ -129,6 +130,7 @@ ULONG EVNTAPI EventRegister( _In_ LPCGUID ProviderId, _In_opt_ PENABLECALLBACK E
 }
 
 // Redirector function for EventWrite. Called by macros in ETWProviderGenerated.h
+_Success_(return == ERROR_SUCCESS)
 ULONG EVNTAPI EventWrite( _In_ REGHANDLE RegHandle, _In_ PCEVENT_DESCRIPTOR EventDescriptor, _In_ ULONG UserDataCount, _In_reads_opt_(UserDataCount) PEVENT_DATA_DESCRIPTOR UserData )
 {
 	if ( g_ETWRegister.m_pEventWrite )
@@ -137,6 +139,7 @@ ULONG EVNTAPI EventWrite( _In_ REGHANDLE RegHandle, _In_ PCEVENT_DESCRIPTOR Even
 }
 
 // Redirector function for EventUnregister. Called by macros in ETWProviderGenerated.h
+_Success_(return == ERROR_SUCCESS)
 ULONG EVNTAPI EventUnregister( _In_ REGHANDLE RegHandle )
 {
 	if ( g_ETWRegister.m_pEventUnregister )

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -165,31 +165,31 @@ static float QPCToMS( int64 nDelta )
 
 // Public functions for emitting ETW events.
 
-void ETWMark( const char *pMessage )
+void ETWMark( _In_z_ PCSTR pMessage )
 {
 	EventWriteMark( pMessage );
 }
 
-void ETWMark1I(const char* pMessage, int data1)
+void ETWMark1I(_In_z_ PCSTR pMessage, int data1)
 {
 	EventWriteMark1I( pMessage, data1 );
 }
 
-void ETWMark2I(const char* pMessage, int data1, int data2)
+void ETWMark2I(_In_z_ PCSTR pMessage, int data1, int data2)
 {
 	EventWriteMark2I( pMessage, data1, data2 );
 }
 
-void ETWMark1F(const char* pMessage, float data1)
+void ETWMark1F(_In_z_ PCSTR pMessage, float data1)
 {
 	EventWriteMark1F( pMessage, data1 );
 }
-void ETWMark2F(const char* pMessage, float data1, float data2)
+void ETWMark2F(_In_z_ PCSTR pMessage, float data1, float data2)
 {
 	EventWriteMark2F( pMessage, data1, data2 );
 }
 
-void ETWMarkPrintf( const char *pMessage, ... )
+void ETWMarkPrintf( _In_z_ PCSTR pMessage, ... )
 {
 	// If we are running on Windows XP or if our providers have not been enabled
 	// (by xperf or other) then this will be false and we can early out.
@@ -211,7 +211,7 @@ void ETWMarkPrintf( const char *pMessage, ... )
 	EventWriteMark( buffer );
 }
 
-void ETWMarkWorkingSet(const wchar_t* pProcessName, const wchar_t* pProcess, unsigned privateWS, unsigned PSS, unsigned workingSet)
+void ETWMarkWorkingSet(_In_z_ PCWSTR pProcessName, _In_z_ PCWSTR pProcess, unsigned privateWS, unsigned PSS, unsigned workingSet)
 {
 	EventWriteMarkWorkingSet(pProcessName, pProcess, privateWS, PSS, workingSet);
 }
@@ -222,7 +222,7 @@ void ETWMarkWorkingSet(const wchar_t* pProcessName, const wchar_t* pProcess, uns
 // on Vista+ that doesn't matter.
 static __declspec( thread ) int s_nDepth;
 
-int64 ETWBegin( const char *pMessage )
+int64 ETWBegin( _In_z_ PCSTR pMessage )
 {
 	// If we are running on Windows XP or if our providers have not been enabled
 	// (by xperf or other) then this will be false and we can early out.
@@ -242,7 +242,7 @@ int64 ETWBegin( const char *pMessage )
 	return nTime;
 }
 
-int64 ETWEnd( const char *pMessage, int64 nStartTime )
+int64 ETWEnd( _In_z_ PCSTR pMessage, int64 nStartTime )
 {
 	// If we are running on Windows XP or if our providers have not been enabled
 	// (by xperf or other) then this will be false and we can early out.
@@ -264,12 +264,12 @@ int64 ETWEnd( const char *pMessage, int64 nStartTime )
 
 
 
-void ETWWorkerMark( const char *pMessage )
+void ETWWorkerMark( _In_z_ PCSTR pMessage )
 {
 	EventWriteMarkWorker( pMessage );
 }
 
-void ETWWorkerMarkPrintf( const char *pMessage, ... )
+void ETWWorkerMarkPrintf( _Printf_format_string_ _In_z_ PCSTR pMessage, ... )
 {
 	// If we are running on Windows XP or if our providers have not been enabled
 	// (by xperf or other) then this will be false and we can early out.
@@ -297,7 +297,7 @@ void ETWWorkerMarkPrintf( const char *pMessage, ... )
 // on Vista+ that doesn't matter.
 static __declspec( thread ) int s_nWorkerDepth;
 
-int64 ETWWorkerBegin( const char *pMessage )
+int64 ETWWorkerBegin( _In_z_ PCSTR pMessage )
 {
 	// If we are running on Windows XP or if our providers have not been enabled
 	// (by xperf or other) then this will be false and we can early out.
@@ -317,7 +317,7 @@ int64 ETWWorkerBegin( const char *pMessage )
 	return nTime;
 }
 
-int64 ETWWorkerEnd( const char *pMessage, int64 nStartTime )
+int64 ETWWorkerEnd( _In_z_ PCSTR pMessage, int64 nStartTime )
 {
 	// If we are running on Windows XP or if our providers have not been enabled
 	// (by xperf or other) then this will be false and we can early out.

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -127,7 +127,7 @@ ULONG EVNTAPI EventRegister( _In_ LPCGUID ProviderId, _In_opt_ PENABLECALLBACK E
 	if ( g_ETWRegister.m_pEventRegister )
 		return g_ETWRegister.m_pEventRegister( ProviderId, EnableCallback, CallbackContext, RegHandle );
 
-	return 0;
+	return ERROR_INVALID_FUNCTION;
 }
 
 // Redirector function for EventWrite. Called by macros in ETWProviderGenerated.h
@@ -137,7 +137,7 @@ ULONG EVNTAPI EventWrite( _In_ REGHANDLE RegHandle, _In_ PCEVENT_DESCRIPTOR Even
 {
 	if ( g_ETWRegister.m_pEventWrite )
 		return g_ETWRegister.m_pEventWrite( RegHandle, EventDescriptor, UserDataCount, UserData );
-	return 0;
+	return ERROR_INVALID_FUNCTION;
 }
 
 // Redirector function for EventUnregister. Called by macros in ETWProviderGenerated.h
@@ -147,7 +147,7 @@ ULONG EVNTAPI EventUnregister( _In_ REGHANDLE RegHandle )
 {
 	if ( g_ETWRegister.m_pEventUnregister )
 		return g_ETWRegister.m_pEventUnregister( RegHandle );
-	return 0;
+	return ERROR_INVALID_FUNCTION;
 }
 
 // Call QueryPerformanceCounter

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -189,7 +189,7 @@ void ETWMark2F(_In_z_ PCSTR pMessage, float data1, float data2)
 	EventWriteMark2F( pMessage, data1, data2 );
 }
 
-void ETWMarkPrintf( _In_z_ PCSTR pMessage, ... )
+void ETWMarkPrintf( _Printf_format_string_ _In_z_ PCSTR pMessage, ... )
 {
 	// If we are running on Windows XP or if our providers have not been enabled
 	// (by xperf or other) then this will be false and we can early out.

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -59,9 +59,9 @@ limitations under the License.
 #include "ETWProvidersGenerated.h"
 
 // Typedefs for use with GetProcAddress
-typedef ULONG (__stdcall *tEventRegister)( LPCGUID ProviderId, PENABLECALLBACK EnableCallback, PVOID CallbackContext, PREGHANDLE RegHandle);
-typedef ULONG (__stdcall *tEventWrite)( REGHANDLE RegHandle, PCEVENT_DESCRIPTOR EventDescriptor, ULONG UserDataCount, PEVENT_DATA_DESCRIPTOR UserData);
-typedef ULONG (__stdcall *tEventUnregister)( REGHANDLE RegHandle );
+typedef _Success_(return == ERROR_SUCCESS) ULONG (__stdcall *tEventRegister)( _In_ LPCGUID ProviderId, _In_opt_ PENABLECALLBACK EnableCallback, _In_opt_ PVOID CallbackContext, _Out_ PREGHANDLE RegHandle);
+typedef _Success_(return == ERROR_SUCCESS) ULONG (__stdcall *tEventWrite)( _In_ REGHANDLE RegHandle, _In_ PCEVENT_DESCRIPTOR EventDescriptor, _In_ ULONG UserDataCount, _In_reads_opt_(UserDataCount) PEVENT_DATA_DESCRIPTOR UserData);
+typedef _Success_(return == ERROR_SUCCESS) ULONG (__stdcall *tEventUnregister)( _In_ REGHANDLE RegHandle );
 
 // Helper class to dynamically load Advapi32.dll, find the ETW functions, 
 // register the providers if possible, and get the performance counter frequency.
@@ -141,6 +141,7 @@ ULONG EVNTAPI EventWrite( _In_ REGHANDLE RegHandle, _In_ PCEVENT_DESCRIPTOR Even
 }
 
 // Redirector function for EventUnregister. Called by macros in ETWProviderGenerated.h
+// Maybe _Post_ptr_invalid_/_Post_invalid_ would be a good idea?
 #pragma warning(suppress: 28253)
 _Success_(return == ERROR_SUCCESS)
 ULONG EVNTAPI EventUnregister( _In_ REGHANDLE RegHandle )
@@ -391,7 +392,7 @@ void ETWMouseWheel( unsigned int flags, int zDelta, int nX, int nY )
 	EventWriteMouse_wheel( flags, zDelta, nX, nY );
 }
 
-void ETWKeyDown( unsigned nChar, const char* keyName, unsigned nRepCnt, unsigned flags )
+void ETWKeyDown( unsigned nChar, _In_opt_z_ const char* keyName, unsigned nRepCnt, unsigned flags )
 {
 	EventWriteKey_down( nChar, keyName, nRepCnt, flags );
 }

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -120,7 +120,7 @@ public:
 } g_ETWRegister;
 
 // Redirector function for EventRegister. Called by macros in ETWProviderGenerated.h
-ULONG EVNTAPI EventRegister( LPCGUID ProviderId, PENABLECALLBACK EnableCallback, PVOID CallbackContext, PREGHANDLE RegHandle )
+ULONG EVNTAPI EventRegister( _In_ LPCGUID ProviderId, _In_opt_ PENABLECALLBACK EnableCallback, _In_opt_ PVOID CallbackContext, _Out_ PREGHANDLE RegHandle )
 {
 	if ( g_ETWRegister.m_pEventRegister )
 		return g_ETWRegister.m_pEventRegister( ProviderId, EnableCallback, CallbackContext, RegHandle );

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -129,7 +129,7 @@ ULONG EVNTAPI EventRegister( _In_ LPCGUID ProviderId, _In_opt_ PENABLECALLBACK E
 }
 
 // Redirector function for EventWrite. Called by macros in ETWProviderGenerated.h
-ULONG EVNTAPI EventWrite( REGHANDLE RegHandle, PCEVENT_DESCRIPTOR EventDescriptor, ULONG UserDataCount, PEVENT_DATA_DESCRIPTOR UserData )
+ULONG EVNTAPI EventWrite( _In_ REGHANDLE RegHandle, _In_ PCEVENT_DESCRIPTOR EventDescriptor, _In_ ULONG UserDataCount, _In_reads_opt_(UserDataCount) PEVENT_DATA_DESCRIPTOR UserData )
 {
 	if ( g_ETWRegister.m_pEventWrite )
 		return g_ETWRegister.m_pEventWrite( RegHandle, EventDescriptor, UserDataCount, UserData );

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -120,6 +120,7 @@ public:
 } g_ETWRegister;
 
 // Redirector function for EventRegister. Called by macros in ETWProviderGenerated.h
+#pragma warning(suppress: 28253)
 _Success_(return == ERROR_SUCCESS)
 ULONG EVNTAPI EventRegister( _In_ LPCGUID ProviderId, _In_opt_ PENABLECALLBACK EnableCallback, _In_opt_ PVOID CallbackContext, _Out_ PREGHANDLE RegHandle )
 {
@@ -130,6 +131,7 @@ ULONG EVNTAPI EventRegister( _In_ LPCGUID ProviderId, _In_opt_ PENABLECALLBACK E
 }
 
 // Redirector function for EventWrite. Called by macros in ETWProviderGenerated.h
+#pragma warning(suppress: 28253)
 _Success_(return == ERROR_SUCCESS)
 ULONG EVNTAPI EventWrite( _In_ REGHANDLE RegHandle, _In_ PCEVENT_DESCRIPTOR EventDescriptor, _In_ ULONG UserDataCount, _In_reads_opt_(UserDataCount) PEVENT_DATA_DESCRIPTOR UserData )
 {
@@ -139,6 +141,7 @@ ULONG EVNTAPI EventWrite( _In_ REGHANDLE RegHandle, _In_ PCEVENT_DESCRIPTOR Even
 }
 
 // Redirector function for EventUnregister. Called by macros in ETWProviderGenerated.h
+#pragma warning(suppress: 28253)
 _Success_(return == ERROR_SUCCESS)
 ULONG EVNTAPI EventUnregister( _In_ REGHANDLE RegHandle )
 {

--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -25,7 +25,7 @@ limitations under the License.
 #include <stdio.h>
 #include "ETWProviders\etwprof.h"
 
-#ifdef	ETW_MARKS_ENABLED
+#ifdef ETW_MARKS_ENABLED
 
 // After building the DLL if it has never been registered on this machine or
 // if the providers have changed you need to go:

--- a/include/ETWProviders/etwprof.h
+++ b/include/ETWProviders/etwprof.h
@@ -78,7 +78,7 @@ PLATFORM_INTERFACE void ETWMouseDown( int nWhichButton, unsigned flags, int nX, 
 PLATFORM_INTERFACE void ETWMouseUp( int nWhichButton, unsigned flags, int nX, int nY );
 PLATFORM_INTERFACE void ETWMouseMove( unsigned flags, int nX, int nY );
 PLATFORM_INTERFACE void ETWMouseWheel( unsigned flags, int zDelta, int nX, int nY );
-PLATFORM_INTERFACE void ETWKeyDown( unsigned nChar, const char* keyName, unsigned nRepCnt, unsigned flags );
+PLATFORM_INTERFACE void ETWKeyDown( unsigned nChar, _In_opt_z_ const char* keyName, unsigned nRepCnt, unsigned flags );
 
 // This class calls the ETW Begin and End functions in order to insert a
 // pair of events to bracket some work.

--- a/include/ETWProviders/etwprof.h
+++ b/include/ETWProviders/etwprof.h
@@ -39,32 +39,32 @@ const int kFlagDoubleClick = 100;
 #include <sal.h> // For _Printf_format_string_
 
 // Insert a single event to mark a point in an ETW trace.
-PLATFORM_INTERFACE void ETWMark( const char *pMessage );
+PLATFORM_INTERFACE void ETWMark( _In_z_ PCSTR pMessage );
 // ETWWorkerMark is identical to ETWMark but goes through a different provider,
 // for different grouping.
-PLATFORM_INTERFACE void ETWWorkerMark(const char *pMessage);
+PLATFORM_INTERFACE void ETWWorkerMark(_In_z_ PCSTR pMessage);
 
 // Insert events with one or more generic int or float data fields
-PLATFORM_INTERFACE void ETWMark1I(const char* pMessage, int data1);
-PLATFORM_INTERFACE void ETWMark2I(const char* pMessage, int data1, int data2);
-PLATFORM_INTERFACE void ETWMark1F(const char* pMessage, float data1);
-PLATFORM_INTERFACE void ETWMark2F(const char* pMessage, float data1, float data2);
+PLATFORM_INTERFACE void ETWMark1I(_In_z_ PCSTR pMessage, int data1);
+PLATFORM_INTERFACE void ETWMark2I(_In_z_ PCSTR pMessage, int data1, int data2);
+PLATFORM_INTERFACE void ETWMark1F(_In_z_ PCSTR pMessage, float data1);
+PLATFORM_INTERFACE void ETWMark2F(_In_z_ PCSTR pMessage, float data1, float data2);
 
 // _Printf_format_string_ is used by /analyze
-PLATFORM_INTERFACE void ETWMarkPrintf( _Printf_format_string_ const char *pMessage, ... );
-PLATFORM_INTERFACE void ETWWorkerMarkPrintf( _Printf_format_string_ const char *pMessage, ... );
+PLATFORM_INTERFACE void ETWMarkPrintf( _Printf_format_string_ _In_z_ PCSTR pMessage, ... );
+PLATFORM_INTERFACE void ETWWorkerMarkPrintf( _Printf_format_string_ _In_z_ PCSTR pMessage, ... );
 
 // Private Working Set, Proportional Set Size (shared memory charged proportionally, and total Working Set
-PLATFORM_INTERFACE void ETWMarkWorkingSet(const wchar_t* pProcessName, const wchar_t* pProcess, unsigned privateWS, unsigned PSS, unsigned workingSet);
+PLATFORM_INTERFACE void ETWMarkWorkingSet(_In_z_ PCWSTR pProcessName, _In_z_ PCWSTR pProcess, unsigned privateWS, unsigned PSS, unsigned workingSet);
 
 // Insert a begin event to mark the start of some work. The return value is a 64-bit
 // time stamp which should be passed to the corresponding ETWEnd function.
-PLATFORM_INTERFACE int64 ETWBegin( const char *pMessage );
-PLATFORM_INTERFACE int64 ETWWorkerBegin( const char *pMessage );
+PLATFORM_INTERFACE int64 ETWBegin( _In_z_ PCSTR pMessage );
+PLATFORM_INTERFACE int64 ETWWorkerBegin( _In_z_ PCSTR pMessage );
 
 // Insert a paired end event to mark the end of some work.
-PLATFORM_INTERFACE int64 ETWEnd( const char *pMessage, int64 nStartTime );
-PLATFORM_INTERFACE int64 ETWWorkerEnd( const char *pMessage, int64 nStartTime );
+PLATFORM_INTERFACE int64 ETWEnd( _In_z_ PCSTR pMessage, int64 nStartTime );
+PLATFORM_INTERFACE int64 ETWWorkerEnd( _In_z_ PCSTR pMessage, int64 nStartTime );
 
 // Mark the start of the next render frame.
 PLATFORM_INTERFACE void ETWRenderFrameMark();
@@ -85,7 +85,7 @@ PLATFORM_INTERFACE void ETWKeyDown( unsigned nChar, const char* keyName, unsigne
 class CETWScope
 {
 public:
-	CETWScope( const char *pMessage )
+	CETWScope( _In_z_ PCSTR pMessage )
 		: m_pMessage( pMessage )
 	{
 		m_nStartTime = ETWBegin( pMessage );
@@ -95,11 +95,11 @@ public:
 		ETWEnd( m_pMessage, m_nStartTime );
 	}
 private:
-	// Private and unimplemented to disable copying.
-	CETWScope( const CETWScope& rhs );
-	CETWScope& operator=( const CETWScope& rhs );
+	// disable copying.
+	CETWScope( const CETWScope& rhs ) = delete;
+	CETWScope& operator=( const CETWScope& rhs ) = delete;
 
-	const char* m_pMessage;
+	_Field_z_ PCSTR m_pMessage;
 	int64 m_nStartTime;
 };
 
@@ -138,9 +138,9 @@ public:
 	{
 	}
 private:
-	// Private and unimplemented to disable copying.
-	CETWScope( const CETWScope& rhs );
-	CETWScope& operator=( const CETWScope& rhs );
+	// disable copying.
+	CETWScope( const CETWScope& rhs ) = delete;
+	CETWScope& operator=( const CETWScope& rhs ) = delete;
 };
 
 #endif


### PR DESCRIPTION
Contrary to the name of this branch, I didn't actually investigate the Working Set monitoring performance issues. I did a bunch of cleanup instead.

The cleanup involved:
- Increasing warning level from 3 to 4
- Enabling Code Analysis for all builds (build time is still very fast)
- Adding annotations
- Converting private & unimplemented copy constructors to `delete`d functions
- etc...

There's one `/analyze` warning that I haven't yet figured out, but it's not a critical issue.

I have NOT included the recompiled `.lib`/`.dll` in this PR, as I figured that you might want to do that.