### PR TITLE
fix python 2/3 dict.keys method inconsistency

### DIFF
--- a/bin/IdentifyChromeProcesses.py
+++ b/bin/IdentifyChromeProcesses.py
@@ -48,7 +48,7 @@ def main():
           type = match.groups()[0]
         pid = int(pidRe.match(line).groups()[0])
         pidsByType = pidsByPath.get(exePath, {})
-        pidList = pidsByType.get(type, [])
+        pidList = list(pidsByType.get(type, []))
         pidList.append(pid)
         pidsByType[type] = pidList
         pidsByPath[exePath] = pidsByType
@@ -58,7 +58,7 @@ def main():
     if len(pidsByPath.keys()) > 1:
       print("%s\r" % exePath)
     pidsByType = pidsByPath[exePath]
-    keys = pidsByType.keys()
+    keys = list(pidsByType.keys())
     keys.sort()
     # Note the importance of printing the '\r' so that the
     # output will be compatible with Windows edit controls.


### PR DESCRIPTION
[The behavior of dict.keys changed in Python 3](http://blog.labix.org/2008/06/27/watch-out-for-listdictkeys-in-python-3). There's [a version-agnostic way to do this](http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items).

Without this, Python crashes (i.e. a `Traceback (most recent call last):` "crash").