### PR TITLE
Fix `LocalAlloc`/`pdidd` NULL deref warning

### DIFF
--- a/UIforETW/PowerStatus.cpp
+++ b/UIforETW/PowerStatus.cpp
@@ -108,125 +108,179 @@ void CPowerStatusMonitor::SampleBatteryStat()
 	for (int deviceNum = 0; deviceNum < maxBatteries; deviceNum++)
 	{
 		SP_DEVICE_INTERFACE_DATA did = { sizeof(did) };
-
-		if (SetupDiEnumDeviceInterfaces(hdev,
+		const BOOL enumDeviceInterfacesResult =
+			SetupDiEnumDeviceInterfaces(hdev,
 										0,
 										&GUID_DEVCLASS_BATTERY,
 										deviceNum,
-										&did))
+										&did);
+		if (!enumDeviceInterfacesResult)
 		{
-			DWORD bytesNeeded = 0;
-			SetupDiGetDeviceInterfaceDetail(hdev,
+			const DWORD lastErr = ::GetLastError( );
+			if (lastErr == ERROR_NO_MORE_ITEMS)
+			{
+				break; // Enumeration failed - perhaps we're out of items
+			}
+			continue;
+		}
+
+		DWORD bytesNeeded = 0;
+		const BOOL getDetailResult = SetupDiGetDeviceInterfaceDetail(hdev,
+										&did,
+										0,
+										0,
+										&bytesNeeded,
+										0);
+
+		if (getDetailResult)
+		{
+			throw std::logic_error("Expected SetupDiGetDeviceInterfaceDetail failure!");
+		}
+
+		if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+		{
+			continue;
+		}
+
+
+		HLOCAL detailDataAlloc = LocalAlloc(LPTR, bytesNeeded);
+		if (detailDataAlloc == NULL)
+		{
+			std::terminate();
+		}
+
+		auto pdidd =
+			reinterpret_cast<PSP_DEVICE_INTERFACE_DETAIL_DATA const>(detailDataAlloc);
+		pdidd->cbSize = sizeof(*pdidd);
+		
+		const BOOL batteryFound = SetupDiGetDeviceInterfaceDetail(hdev,
 											&did,
-											0,
-											0,
+											pdidd,
+											bytesNeeded,
 											&bytesNeeded,
 											0);
-
-			if (GetLastError() == ERROR_INSUFFICIENT_BUFFER)
-			{
-				auto pdidd = (PSP_DEVICE_INTERFACE_DETAIL_DATA)LocalAlloc(LPTR, bytesNeeded);
-				pdidd->cbSize = sizeof(*pdidd);
-				if (SetupDiGetDeviceInterfaceDetail(hdev,
-													&did,
-													pdidd,
-													bytesNeeded,
-													&bytesNeeded,
-													0))
-				{
-					// Found a battery. Query it.
-					HANDLE hBattery = CreateFile(pdidd->DevicePath,
-									GENERIC_READ | GENERIC_WRITE,
-									FILE_SHARE_READ | FILE_SHARE_WRITE,
-									NULL,
-									OPEN_EXISTING,
-									FILE_ATTRIBUTE_NORMAL,
-									NULL);
-					if (hBattery != INVALID_HANDLE_VALUE)
-					{
-						BATTERY_QUERY_INFORMATION bqi = {};
-
-						DWORD dwWait = 0;
-						DWORD dwOut;
-						if (DeviceIoControl(hBattery,
-											IOCTL_BATTERY_QUERY_TAG,
-											&dwWait,
-											sizeof(dwWait),
-											&bqi.BatteryTag,
-											sizeof(bqi.BatteryTag),
-											&dwOut,
-											NULL)
-											&& bqi.BatteryTag)
-						{
-							// With the tag, you can query the battery info.
-							BATTERY_INFORMATION bi = {};
-							bqi.InformationLevel = BatteryInformation;
-
-							if (DeviceIoControl(hBattery,
-												IOCTL_BATTERY_QUERY_INFORMATION,
-												&bqi,
-												sizeof(bqi),
-												&bi,
-												sizeof(bi),
-												&dwOut,
-												NULL))
-							{
-								// Only non-UPS system batteries count
-								if (bi.Capabilities & BATTERY_SYSTEM_BATTERY)
-								{
-									// Query the battery status.
-									BATTERY_WAIT_STATUS bws = {};
-									bws.BatteryTag = bqi.BatteryTag;
-
-									BATTERY_STATUS bs;
-									if (DeviceIoControl(hBattery,
-														IOCTL_BATTERY_QUERY_STATUS,
-														&bws,
-														sizeof(bws),
-														&bs,
-														sizeof(bs),
-														&dwOut,
-														NULL))
-									{
-										char powerState[100];
-										powerState[0] = 0;
-										if (bs.PowerState & BATTERY_CHARGING)
-											strcat_s(powerState, "Charging");
-										if (bs.PowerState & BATTERY_DISCHARGING)
-											strcat_s(powerState, "Discharging");
-										if (bs.PowerState & BATTERY_POWER_ON_LINE)
-										{
-											if (powerState[0])
-												strcat_s(powerState, ", on AC power");
-											else
-												strcat_s(powerState, "On AC power");
-										}
-
-										float batPercentage = bs.Capacity * 100.f / bi.FullChargedCapacity;
-
-										char rate[100];
-										if (bs.Rate == BATTERY_UNKNOWN_RATE)
-											sprintf_s(rate, "Unknown rate");
-										else if (bi.Capabilities & BATTERY_CAPACITY_RELATIVE)
-											sprintf_s(rate, "%ld (unknown units)", bs.Rate);
-										else
-											sprintf_s(rate, "%1.3f watts", bs.Rate / 1000.0f);
-										ETWMarkBatteryStatus(powerState, batPercentage, rate);
-										//outputPrintf(L"%S, %1.3f%%, %S\n", powerState, batPercentage, rate);
-									}
-								}
-							}
-						}
-						CloseHandle(hBattery);
-					}
-				}
-				LocalFree(pdidd);
-			}
-		}
-		else  if (ERROR_NO_MORE_ITEMS == GetLastError())
+		if (!batteryFound)
 		{
-			break;  // Enumeration failed - perhaps we're out of items
+			FreeLocalAlloc(detailDataAlloc);//use `detailDataAlloc` to suppress
+			                                //analyze warning about using
+			                                //`pdidd` from failed
+			                                //`SetupDiGetDeviceInterfaceDetail`
+			                                //call...
+			continue;
 		}
+
+		// Found a battery. Query it.
+		HANDLE hBattery = CreateFile(pdidd->DevicePath,
+						GENERIC_READ | GENERIC_WRITE,
+						FILE_SHARE_READ | FILE_SHARE_WRITE,
+						NULL,
+						OPEN_EXISTING,
+						FILE_ATTRIBUTE_NORMAL,
+						NULL);
+
+		if (hBattery == INVALID_HANDLE_VALUE)
+		{
+			FreeLocalAlloc(pdidd);
+			continue;
+		}
+
+		BATTERY_QUERY_INFORMATION bqi = {};
+
+		DWORD dwWait = 0;
+		DWORD dwOut;
+
+		const BOOL tagQueried = DeviceIoControl(hBattery,
+												IOCTL_BATTERY_QUERY_TAG,
+												&dwWait,
+												sizeof(dwWait),
+												&bqi.BatteryTag,
+												sizeof(bqi.BatteryTag),
+												&dwOut,
+												NULL);
+
+		if (!(tagQueried && bqi.BatteryTag))
+		{
+			FreeLocalAlloc(pdidd);
+			CloseValidHandle(hBattery);
+			continue;
+		}
+
+		// With the tag, you can query the battery info.
+		BATTERY_INFORMATION bi = {};
+		bqi.InformationLevel = BatteryInformation;
+		
+		const BOOL infoQueried = DeviceIoControl(hBattery,
+												 IOCTL_BATTERY_QUERY_INFORMATION,
+												 &bqi,
+												 sizeof(bqi),
+												 &bi,
+												 sizeof(bi),
+												 &dwOut,
+												 NULL);
+		if (!infoQueried)
+		{
+			FreeLocalAlloc(pdidd);
+			CloseValidHandle(hBattery);
+			continue;
+		}
+
+		// Only non-UPS system batteries count
+		if (!(bi.Capabilities & BATTERY_SYSTEM_BATTERY))
+		{
+			FreeLocalAlloc(pdidd);
+			CloseValidHandle(hBattery);
+			continue;
+		}
+
+
+		// Query the battery status.
+		BATTERY_WAIT_STATUS bws = {};
+		bws.BatteryTag = bqi.BatteryTag;
+
+		BATTERY_STATUS bs;
+		
+		const BOOL statusQueried = DeviceIoControl(hBattery,
+												   IOCTL_BATTERY_QUERY_STATUS,
+												   &bws,
+												   sizeof(bws),
+												   &bs,
+												   sizeof(bs),
+												   &dwOut,
+												   NULL);
+		if (!statusQueried)
+		{
+			FreeLocalAlloc(pdidd);
+			CloseValidHandle(hBattery);
+			continue;
+		}
+
+		char powerState[100];
+		powerState[0] = 0;
+		if (bs.PowerState & BATTERY_CHARGING)
+			strcat_s(powerState, "Charging");
+		if (bs.PowerState & BATTERY_DISCHARGING)
+			strcat_s(powerState, "Discharging");
+		if (bs.PowerState & BATTERY_POWER_ON_LINE)
+		{
+			if (powerState[0])
+				strcat_s(powerState, ", on AC power");
+			else
+				strcat_s(powerState, "On AC power");
+		}
+
+		float batPercentage = bs.Capacity * 100.f / bi.FullChargedCapacity;
+
+		char rate[100];
+		if (bs.Rate == BATTERY_UNKNOWN_RATE)
+			sprintf_s(rate, "Unknown rate");
+		else if (bi.Capabilities & BATTERY_CAPACITY_RELATIVE)
+			sprintf_s(rate, "%ld (unknown units)", bs.Rate);
+		else
+			sprintf_s(rate, "%1.3f watts", bs.Rate / 1000.0f);
+		ETWMarkBatteryStatus(powerState, batPercentage, rate);
+		//outputPrintf(L"%S, %1.3f%%, %S\n", powerState, batPercentage, rate);
+		CloseValidHandle(hBattery);
+		FreeLocalAlloc(pdidd);
 	}
 	SetupDiDestroyDeviceInfoList(hdev);
 }
@@ -237,9 +291,9 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 // NtQueryTimerResolution is not officially documented.
 const NTSTATUS STATUS_SUCCESS = 0;
 extern "C" NTSYSAPI NTSTATUS NTAPI NtQueryTimerResolution(
-	OUT PULONG minimumResolution,
-	OUT PULONG maximumResolution,
-	OUT PULONG currentResolution);
+	_Out_ PULONG minimumResolution,
+	_Out_ PULONG maximumResolution,
+	_Out_ PULONG currentResolution);
 // Link to ntdll.lib to allow calling of NtQueryTimerResolution
 #pragma comment(lib, "ntdll")
 void CPowerStatusMonitor::SampleTimerState()

--- a/UIforETW/PowerStatus.cpp
+++ b/UIforETW/PowerStatus.cpp
@@ -48,12 +48,7 @@ namespace {
 	{
 		DWORD bytesNeeded = 0;
 		const BOOL getDetailResult = SetupDiGetDeviceInterfaceDetail(hdev,
-										pdid,
-										0,
-										0,
-										&bytesNeeded,
-										0);
-
+										pdid, 0, 0, &bytesNeeded, 0);
 		UIETWASSERT(!getDetailResult);
 		if (getDetailResult)
 		{
@@ -108,6 +103,8 @@ namespace {
 	}
 
 	struct HDEVINFO_battery final {
+		HDEVINFO_battery( const HDEVINFO_battery& ) = delete;
+		HDEVINFO_battery& operator=( const HDEVINFO_battery& ) = delete;
 		HDEVINFO hdev;
 		HDEVINFO_battery( )
 		{
@@ -153,11 +150,10 @@ namespace {
 				return;
 			}
 			CloseValidHandle( hBattery );
-
 		}
 	};
 
-} //namespace {
+} //namespace
 
 void CPowerStatusMonitor::SampleCPUPowerState()
 {

--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -644,13 +644,3 @@ void CloseValidHandle( _Pre_valid_ _Post_ptr_invalid_ HANDLE handle )
 
 }
 
-
-void FreeLocalAlloc( _Post_ptr_invalid_ HLOCAL alloc )
-{
-	const HLOCAL nullIfFreed = ::LocalFree(alloc);
-	if (nullIfFreed != NULL)
-	{
-		std::terminate( );
-	}
-
-}

--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -633,3 +633,24 @@ void CopyStartupProfiles(const std::wstring& exeDir, bool force)
 		}
 	}
 }
+
+void CloseValidHandle( _Pre_valid_ _Post_ptr_invalid_ HANDLE handle )
+{
+	const BOOL handleClosed = ::CloseHandle(handle);
+	if (handleClosed == 0)
+	{
+		std::terminate( );
+	}
+
+}
+
+
+void FreeLocalAlloc( _Post_ptr_invalid_ HLOCAL alloc )
+{
+	const HLOCAL nullIfFreed = ::LocalFree(alloc);
+	if (nullIfFreed != NULL)
+	{
+		std::terminate( );
+	}
+
+}

--- a/UIforETW/Utility.h
+++ b/UIforETW/Utility.h
@@ -113,4 +113,3 @@ void CopyStartupProfiles(const std::wstring& exeDir, bool force);
 
 void CloseValidHandle( _Pre_valid_ _Post_ptr_invalid_ HANDLE handle );
 
-void FreeLocalAlloc( _Post_ptr_invalid_ HLOCAL alloc );

--- a/UIforETW/Utility.h
+++ b/UIforETW/Utility.h
@@ -110,3 +110,7 @@ std::wstring GetEXEBuildTime();
 void SetCurrentThreadName(char* threadName);
 
 void CopyStartupProfiles(const std::wstring& exeDir, bool force);
+
+void CloseValidHandle( _Pre_valid_ _Post_ptr_invalid_ HANDLE handle );
+
+void FreeLocalAlloc( _Post_ptr_invalid_ HLOCAL alloc );


### PR DESCRIPTION
`/analyze` complained:

```
C28182 Dereferencing a copy of a null pointer 'pdidd' contains the same
NULL value as 'LocalAlloc()`128' did.
139 'pdidd' may be NULL
140 'pdidd' is dereferenced, but may still be NULL
```

So, I inserted a `NULL` check, and simply `std::terminate()` if
`LocalAlloc` fails, as it means we're probably OOM (unless there's an
***absurdly*** large `DevicePath` in `SP_DEVICE_INTERFACE_DETAIL_DATA`).

There were so many levels of indentation in
`CPowerStatusMonitor::SampleBatteryStat` that it was giving me a
headache, so I went ahead and 'unrolled' it. Is that ok?

Because I'm crazy about checking return values, I added two wrapper
functions to `Utility.h`/`Utility.cpp` (`FreeLocalAlloc` and
`CloseValidHandle`), as if the wrapped system calls ever fail, there's a
bug on our side of things.

As a drive-by fix, I also changed the `OUT` pseudo-annotated parameters
of `NtQueryTimerResolution` (`OUT` is defined to ` ` - blank text) to
`_Out_`, so that `/analyze` treats them as actual out parameters.

**PLEASE NOTE**:

There's another code analysis warning that is ***NOT*** correct

```
C6102		Using 'bytesNeeded' from failed function call at line '132'.
	128	'bytesNeeded' is not initialized
	135	Skip this branch, (assume 'getDetailResult' is false)
	140	Skip this branch, (assume 'GetLastError()!=122' is false)
	146	'bytesNeeded' is an Input to 'LocalAlloc' (declared at c:\program files (x86)\windows kits\8.1\include\um\winbase.h:1039)
	146	'bytesNeeded' is used, but may not have been initialized
```

... Microsoft just hasn't properly annotated `SetupDiGetDeviceInterfaceDetail`
to say that the 5th parameter is valid under certain failure conditions
(i.e. `_On_failure_( _When_( ( _Param_( 3 ) == 0 ) && ( _Param_( 4 ) == 0 ), _Post_valid_ ) )`...)