### PR TITLE
If IntelEnergyLibInitialize fails, pretend that the library does not exist

### DIFF
--- a/UIforETW/PowerStatus.cpp
+++ b/UIforETW/PowerStatus.cpp
@@ -382,13 +382,30 @@ CPowerStatusMonitor::CPowerStatusMonitor()
 			GetMaxTemperature(0, &maxTemperature_);
 		if (IntelEnergyLibInitialize && ReadSample)
 		{
-			IntelEnergyLibInitialize();
-			ReadSample();
+			if (IntelEnergyLibInitialize())
+			{
+				ReadSample();
+			}
+			else
+			{
+				// Mark the library as unavailable if Initialize fails
+				ClearEnergyLibFunctionPointers();
+			}
 		}
 	}
 
 	hExitEvent_ = CreateEvent(nullptr, FALSE, FALSE, nullptr);
 	hThread_ = CreateThread(NULL, 0, StaticPowerMonitorThread, this, 0, nullptr);
+}
+
+void CPowerStatusMonitor::ClearEnergyLibFunctionPointers()
+{
+	IntelEnergyLibInitialize = nullptr;
+	GetNumMsrs = nullptr;
+	GetMsrName = nullptr;
+	GetMsrFunc = nullptr;
+	GetPowerData = nullptr;
+	ReadSample = nullptr;
 }
 
 CPowerStatusMonitor::~CPowerStatusMonitor()

--- a/UIforETW/PowerStatus.h
+++ b/UIforETW/PowerStatus.h
@@ -38,6 +38,7 @@ private:
 	void SampleBatteryStat();
 	void SampleCPUPowerState();
 	void SampleTimerState();
+	void ClearEnergyLibFunctionPointers();
 
 	HANDLE hThread_;
 	HANDLE hExitEvent_;


### PR DESCRIPTION
This is primarily to fix an access violation when initially calling ReadSample I experienced with two different Xeon processors, but generally seems like good behavior.