### PR TITLE
Removed usage of MFC "feature pack" classes.

### DIFF
--- a/UIforETW/Settings.cpp
+++ b/UIforETW/Settings.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 #include "UIforETW.h"
 #include "Settings.h"
 #include "Utility.h"
-#include "afxdialogex.h"
 
 /*
 When doing Chrome profilng it is possible to ask various Chrome tracing
@@ -64,10 +63,10 @@ uint64_t disabled_other_events_keyword_bit = 1ULL << 62;
 
 // CSettings dialog
 
-IMPLEMENT_DYNAMIC(CSettings, CDialogEx)
+IMPLEMENT_DYNAMIC(CSettings, CDialog)
 
 CSettings::CSettings(CWnd* pParent /*=NULL*/, const std::wstring& exeDir, const std::wstring& wptDir, const std::wstring& wpt10Dir)
-	: CDialogEx(CSettings::IDD, pParent)
+	: CDialog(CSettings::IDD, pParent)
 	, exeDir_(exeDir)
 	, wptDir_(wptDir)
 	, wpt10Dir_(wpt10Dir)
@@ -95,11 +94,11 @@ void CSettings::DoDataExchange(CDataExchange* pDX)
 	DDX_Control(pDX, IDC_VIRTUALALLOCSTACKS, btVirtualAllocStacks_);
 	DDX_Control(pDX, IDC_CHROME_CATEGORIES, btChromeCategories_);
 
-	CDialogEx::DoDataExchange(pDX);
+	CDialog::DoDataExchange(pDX);
 }
 
 
-BEGIN_MESSAGE_MAP(CSettings, CDialogEx)
+BEGIN_MESSAGE_MAP(CSettings, CDialog)
 	ON_BN_CLICKED(IDC_COPYSTARTUPPROFILE, &CSettings::OnBnClickedCopystartupprofile)
 	ON_BN_CLICKED(IDC_COPYSYMBOLDLLS, &CSettings::OnBnClickedCopysymboldlls)
 	ON_BN_CLICKED(IDC_CHROMEDEVELOPER, &CSettings::OnBnClickedChromedeveloper)
@@ -111,7 +110,7 @@ END_MESSAGE_MAP()
 
 BOOL CSettings::OnInitDialog()
 {
-	CDialogEx::OnInitDialog();
+	CDialog::OnInitDialog();
 
 	SetDlgItemText(IDC_HEAPEXE, heapTracingExes_.c_str());
 	CheckDlgButton(IDC_CHROMEDEVELOPER, bChromeDeveloper_);

--- a/UIforETW/Settings.h
+++ b/UIforETW/Settings.h
@@ -21,7 +21,7 @@ limitations under the License.
 
 // CSettings dialog
 
-class CSettings : public CDialogEx
+class CSettings : public CDialog
 {
 	DECLARE_DYNAMIC(CSettings)
 

--- a/UIforETW/UIforETW.cpp
+++ b/UIforETW/UIforETW.cpp
@@ -188,14 +188,6 @@ BOOL CUIforETWApp::InitInstance()
 
 	CWinApp::InitInstance();
 
-	// Create the shell manager, in case the dialog contains
-	// any shell tree view or shell list view controls.
-	// Code mysteriously inserted by MFC.
-	auto pShellManager = std::make_unique<CShellManager>();
-
-	// Activate "Windows Native" visual manager for enabling themes in MFC controls
-	CMFCVisualManager::SetDefaultManager(RUNTIME_CLASS(CMFCVisualManagerWindows));
-
 	SetRegistryKey(L"RandomASCII");
 
 	HWND prevWindow = FindWindow(NULL, L"UI for ETW");

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -19,7 +19,6 @@ limitations under the License.
 #include "UIforETWDlg.h"
 
 #include "About.h"
-#include "afxdialogex.h"
 #include "ChildProcess.h"
 #include "Settings.h"
 #include "Utility.h"
@@ -30,6 +29,7 @@ limitations under the License.
 #include <ETWProviders\etwprof.h>
 #include <vector>
 #include <map>
+#include <ShlObj.h>
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -82,7 +82,7 @@ void CUIforETWDlg::vprintf(const wchar_t* pFormat, va_list args)
 
 
 CUIforETWDlg::CUIforETWDlg(CWnd* pParent /*=NULL*/)
-	: CDialogEx(CUIforETWDlg::IDD, pParent)
+	: CDialog(CUIforETWDlg::IDD, pParent)
 	, monitorThread_(this)
 {
 	pMainWindow = this;
@@ -169,11 +169,11 @@ void CUIforETWDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Control(pDX, IDC_OUTPUT, btOutput_);
 	DDX_Control(pDX, IDC_TRACENAMEEDIT, btTraceNameEdit_);
 
-	CDialogEx::DoDataExchange(pDX);
+	CDialog::DoDataExchange(pDX);
 }
 
 // Hook up functions to messages from buttons, menus, etc.
-BEGIN_MESSAGE_MAP(CUIforETWDlg, CDialogEx)
+BEGIN_MESSAGE_MAP(CUIforETWDlg, CDialog)
 	ON_WM_SYSCOMMAND()
 	ON_WM_PAINT()
 	ON_WM_QUERYDRAGICON()
@@ -240,7 +240,7 @@ void CUIforETWDlg::SetSymbolPath()
 
 BOOL CUIforETWDlg::OnInitDialog()
 {
-	CDialogEx::OnInitDialog();
+	CDialog::OnInitDialog();
 
 	// Load the F2 (rename) and ESC (silently swallow ESC) accelerators
 	hAccelTable_ = LoadAccelerators(AfxGetInstanceHandle(), MAKEINTRESOURCE(IDR_ACCELERATORS));
@@ -669,7 +669,7 @@ void CUIforETWDlg::OnSysCommand(UINT nID, LPARAM lParam)
 	}
 	else
 	{
-		CDialogEx::OnSysCommand(nID, lParam);
+		CDialog::OnSysCommand(nID, lParam);
 	}
 }
 
@@ -698,7 +698,7 @@ void CUIforETWDlg::OnPaint()
 	}
 	else
 	{
-		CDialogEx::OnPaint();
+		CDialog::OnPaint();
 	}
 }
 

--- a/UIforETW/UIforETWDlg.h
+++ b/UIforETW/UIforETWDlg.h
@@ -32,7 +32,7 @@ enum TracingMode
 	kHeapTracingToFile
 };
 
-class CUIforETWDlg : public CDialogEx
+class CUIforETWDlg : public CDialog
 {
 public:
 	CUIforETWDlg(CWnd* pParent = NULL);	// standard constructor

--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include "Utility.h"
 #include <fstream>
 #include <direct.h>
+#include <ShlObj.h>
 
 std::vector<std::wstring> split(const std::wstring& s, char c)
 {

--- a/UIforETW/stdafx.h
+++ b/UIforETW/stdafx.h
@@ -19,6 +19,11 @@ limitations under the License.
 // Include this first so that the requested version is known.
 #include "targetver.h"
 
+// disable the MFC "feature pack" controls
+// they end up bringing dependencies on DLLs that are not 
+// documented as available on the Server Core SKUs.
+#define _AFX_NO_MFC_CONTROLS_IN_DIALOGS
+
 #ifndef VC_EXTRALEAN
 #define VC_EXTRALEAN            // Exclude rarely-used stuff from Windows headers
 #endif
@@ -39,7 +44,8 @@ limitations under the License.
 #include <afxcmn.h>             // MFC support for Windows Common Controls
 #endif // _AFX_NO_AFXCMN_SUPPORT
 
-#include <afxcontrolbars.h>     // MFC support for ribbons and control bars
+#include <afxmt.h>
+
 #include <atlwin.h>
 #include <sal.h>
 #include <VersionHelpers.h>


### PR DESCRIPTION
The primary goal of this is to remove dependencies on DLLs that are not included in the list of DLLs that are supported on the Windows Server Core configurations. This removes the dependencies on MSIMG32.dll, gdiplus.dll, and WINMM.dll. It also gets rid of a dependency on imm32.dll, but that one is actually supported.

As a side effect, this also reduces the static exe size by about 2 megabytes, but the actual benefit of that ends up being minimal.