### PR TITLE
Tweak utility funcs try five, redo of #62

### DIFF
--- a/UIforETW/Support.cpp
+++ b/UIforETW/Support.cpp
@@ -168,7 +168,7 @@ int CUIforETWDlg::BufferCountBoost(int requestCount) const
 		return requestCount;
 
 	const int64_t oneGB = int64_t(1024) * 1024 * 1024;
-	int64_t physicalRam = memoryStatus.ullTotalPhys;
+	const int64_t physicalRam = memoryStatus.ullTotalPhys;
 	if (physicalRam > 15 * oneGB)
 	{
 		numerator = 3;

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -219,8 +219,7 @@ void CUIforETWDlg::SetSymbolPath()
 {
 	// Make sure that the symbol paths are set.
 
-#pragma warning(suppress : 4996)
-	if (bManageSymbolPath_ || !getenv("_NT_SYMBOL_PATH"))
+	if (bManageSymbolPath_ || GetEnvironmentVariableString("_NT_SYMBOL_PATH").empty())
 	{
 		bManageSymbolPath_ = true;
 		std::string symbolPath = "SRV*" + systemDrive_ + "symbols*https://msdl.microsoft.com/download/symbols";
@@ -231,9 +230,8 @@ void CUIforETWDlg::SetSymbolPath()
 			L"Set _NT_SYMBOL_PATH yourself or toggle 'Chrome developer' if you want different defaults.\n",
 			AnsiToUnicode(symbolPath).c_str(), bChromeDeveloper_ ? L" plus Chrome" : L"");
 	}
-#pragma warning(suppress : 4996)
-	const char* symCachePath = getenv("_NT_SYMCACHE_PATH");
-	if (!symCachePath)
+	const std::string symCachePath = GetEnvironmentVariableString("_NT_SYMCACHE_PATH");
+	if (symCachePath.empty())
 		(void)_putenv(("_NT_SYMCACHE_PATH=" + systemDrive_ + "symcache").c_str());
 }
 
@@ -282,7 +280,7 @@ BOOL CUIforETWDlg::OnInitDialog()
 		}
 	}
 
-	if (GetWindowsVersion() == kWindowsVersionXP)
+	if (IsWindowsXPOrLesser())
 	{
 		AfxMessageBox(L"ETW tracing requires Windows Vista or above.");
 		exit(10);
@@ -318,7 +316,7 @@ BOOL CUIforETWDlg::OnInitDialog()
 		if (!PathFileExists(GetXperfPath().c_str()))
 		{
 			// Windows 7 users need to have WPT 8.1 installed.
-			if (GetWindowsVersion() <= kWindowsVersion7)
+			if (IsWindowsSevenOrLesser())
 			{
 				const std::wstring installPath81 = GetExeDir() + L"..\\third_party\\wpt81\\WPTx64-x86_en-us.msi";
 				if (PathFileExists(installPath81.c_str()))
@@ -355,7 +353,7 @@ BOOL CUIforETWDlg::OnInitDialog()
 	}
 	if (!PathFileExists(GetXperfPath().c_str()))
 	{
-		if (GetWindowsVersion() <= kWindowsVersion7)
+		if (IsWindowsSevenOrLesser())
 		{
 			// WPT 10 (at least the 10240 version) doesn't record image ID information
 			// on Windows 7 and below, so the Windows 8.1 version of WPT is needed.
@@ -432,8 +430,7 @@ BOOL CUIforETWDlg::OnInitDialog()
 	SetIcon(m_hIcon, TRUE);			// Set big icon
 	SetIcon(m_hIcon, FALSE);		// Set small icon
 
-	WindowsVersion winver = GetWindowsVersion();
-	if (winver <= kWindowsVersion7)
+	if (IsWindowsSevenOrLesser())
 	{
 		bCompress_ = false; // ETW trace compression requires Windows 8.0
 		SmartEnableWindow(btCompress_.m_hWnd, false);
@@ -535,13 +532,12 @@ std::wstring CUIforETWDlg::wpaDefaultPath() const
 	return wpaPath_;
 }
 
-std::wstring CUIforETWDlg::GetDirectory(const wchar_t* env, const std::wstring& default)
+std::wstring CUIforETWDlg::GetDirectory(PCWSTR env, const std::wstring& default)
 {
 	// Get a directory (from an environment variable, if set) and make sure it exists.
 	std::wstring result = default;
-#pragma warning(suppress : 4996)
-	const wchar_t* traceDir = _wgetenv(env);
-	if (traceDir)
+	const std::wstring traceDir = GetEnvironmentVariableString(env);
+	if (!traceDir.empty())
 	{
 		result = traceDir;
 	}
@@ -574,9 +570,8 @@ void CUIforETWDlg::RegisterProviders()
 		dllSource += L"ETWProviders64.dll";
 	else
 		dllSource += L"ETWProviders.dll";
-#pragma warning(suppress:4996)
-	const wchar_t* temp = _wgetenv(L"temp");
-	if (!temp)
+	const std::wstring temp = GetEnvironmentVariableString(L"temp");
+	if (temp.empty())
 		return;
 	std::wstring dllDest = temp;
 	dllDest += L"\\ETWProviders.dll";
@@ -736,10 +731,7 @@ std::wstring CUIforETWDlg::GenerateResultFilename() const
 	_strdate_s(date);
 	int hour, min, sec;
 	int year, month, day;
-#pragma warning(suppress : 4996)
-	const wchar_t* username = _wgetenv(L"USERNAME");
-	if (!username)
-		username = L"";
+	const std::wstring username = GetEnvironmentVariableString(L"USERNAME");
 	wchar_t fileName[MAX_PATH];
 	// Hilarious /analyze warning on this line from bug in _strtime_s annotation!
 	// warning C6054: String 'time' might not be zero-terminated.
@@ -748,7 +740,7 @@ std::wstring CUIforETWDlg::GenerateResultFilename() const
 		3 == sscanf_s(date, "%d/%d/%d", &month, &day, &year))
 	{
 		// The filenames are chosen to sort by date, with username as the LSB.
-		swprintf_s(fileName, L"%04d-%02d-%02d_%02d-%02d-%02d_%s", year + 2000, month, day, hour, min, sec, username);
+		swprintf_s(fileName, L"%04d-%02d-%02d_%02d-%02d-%02d_%s", year + 2000, month, day, hour, min, sec, username.c_str());
 	}
 	else
 	{
@@ -809,7 +801,6 @@ void CUIforETWDlg::OnBnClickedStarttracing()
 		kernelFile = L" -buffering";
 	std::wstring kernelArgs = L" -start " + GetKernelLogger() + L" -on" + kernelProviders + kernelStackWalk + kernelBuffers + kernelFile;
 
-	WindowsVersion winver = GetWindowsVersion();
 	// The Windows 10 ReleaseUserCrit, ExclusiveUserCrit, and SharedUserCrit events generate
 	// 75% of the events for this provider - 33,000/s in one test. They account for
 	// more than 75% of the space used, according to System Configuration-> Trace
@@ -825,7 +816,7 @@ void CUIforETWDlg::OnBnClickedStarttracing()
 	// clear that it actually helps.
 	const uint64_t kCritFlags = 0x0200000010000000;
 	std::wstring userProviders = stringPrintf(L"Microsoft-Windows-Win32k:0x%llx", ~kCritFlags);
-	if (winver <= kWindowsVersionVista)
+	if (IsWindowsVistaOrLesser())
 		userProviders = L"Microsoft-Windows-LUA"; // Because Microsoft-Windows-Win32k doesn't work on Vista.
 	userProviders += L"+Multi-MAIN+Multi-FrameRate+Multi-Input+Multi-Worker";
 
@@ -839,13 +830,13 @@ void CUIforETWDlg::OnBnClickedStarttracing()
 	// some of Chrome's categories (keywords/flags) then add chrome:flags to the list of user
 	// providers to monitor. See https://codereview.chromium.org/1176243016 for details.
 	if (useChromeProviders_)
-		userProviders += stringPrintf(L"+chrome:0x%llx", 0x8000000000000000 | chromeKeywords_);
+		userProviders += stringPrintf(L"+chrome:0x%llx", (0x8000000000000000 | chromeKeywords_));
 
 	if (bGPUTracing_)
 	{
 		// Apparently we need a different provider for graphics profiling
 		// on Windows 8 and above.
-		if (winver >= kWindowsVersion8)
+		if (IsWindows8OrGreater())
 		{
 			// This provider is needed for GPU profiling on Windows 8+
 			userProviders += L"+Microsoft-Windows-DxgKrnl:0xFFFF:5";
@@ -1176,7 +1167,7 @@ void CUIforETWDlg::OnBnClickedShowcommands()
 void CUIforETWDlg::SetSamplingSpeed()
 {
 	std::wstring xperfPath = GetXperfPath();
-	if (GetWindowsVersion() >= kWindowsVersion10)
+	if (IsWindowsTenOrGreater())
 	{
 		xperfPath = wpt10Dir_ + L"xperf.exe";
 		if (!PathFileExists(xperfPath.c_str()))
@@ -1249,8 +1240,8 @@ void CUIforETWDlg::UpdateTraceList()
 
 	// Note that these will also pull in files like *.etlabc and *.zipabc.
 	// I don't want that. Filter them out later?
-	auto tempTraces = GetFileList(GetTraceDir() + L"\\*.etl");
-	auto tempZips = GetFileList(GetTraceDir() + L"\\*.zip");
+	auto tempTraces = GetFileList(GetTraceDir() + L"*.etl");
+	auto tempZips = GetFileList(GetTraceDir() + L"*.zip");
 	// Why can't I use += to concatenate these?
 	tempTraces.insert(tempTraces.end(), tempZips.begin(), tempZips.end());
 	std::sort(tempTraces.begin(), tempTraces.end());
@@ -1626,7 +1617,7 @@ void CUIforETWDlg::OnContextMenu(CWnd* pWnd, CPoint point)
 				pContextMenu->EnableMenuItem(id, MF_BYCOMMAND | MF_GRAYED);
 		}
 
-		if (GetWindowsVersion() < kWindowsVersion8)
+		if (IsWindowsSevenOrLesser())
 		{
 			// Disable ETW trace compress options on Windows 7 and below
 			// since they don't work there.

--- a/UIforETW/UIforETWDlg.h
+++ b/UIforETW/UIforETWDlg.h
@@ -198,7 +198,7 @@ private:
 	void SetSymbolPath();
 	// Call this to retrieve a directory from an environment variable, or use
 	// a default, and make sure it exists.
-	std::wstring GetDirectory(const wchar_t* env, const std::wstring& default);
+	std::wstring GetDirectory(PCWSTR env, const std::wstring& default);
 	void CUIforETWDlg::UpdateTraceList();
 	void RegisterProviders();
 	void DisablePagingExecutive();

--- a/UIforETW/Utility.cpp
+++ b/UIforETW/Utility.cpp
@@ -20,7 +20,133 @@ limitations under the License.
 #include <direct.h>
 #include <ShlObj.h>
 
-std::vector<std::wstring> split(const std::wstring& s, char c)
+
+namespace {
+PCWSTR const kWPAStartupFileName = L"\\Startup.wpaProfile";
+
+void UnlockGlobalMemory(_In_ const HGLOBAL hmem)
+{
+	const BOOL unlockRes = ::GlobalUnlock(hmem);
+	if (!unlockRes)
+	{
+		UIETWASSERT(::GetLastError() == NO_ERROR);
+	}
+}
+
+std::wstring GetDocumentsFolderPath()
+{
+	ATL::CComHeapPtr<_Null_terminated_ wchar_t> docsPathTemp;
+	const HRESULT docsPathResult =
+		::SHGetKnownFolderPath(
+		FOLDERID_Documents, KF_FLAG_NO_ALIAS, NULL, &docsPathTemp.m_pData);
+	if (FAILED(docsPathResult))
+	{
+		debugPrintf(L"SHGetKnownFolderPath (for Documents) failed to retrieve the path.\n");
+		std::terminate();
+	}
+	return docsPathTemp.m_pData;
+}
+
+void copyWPAProfileToDocuments(const bool force)
+{
+	// First copy the WPA 8.1 startup.wpaProfile file
+	std::wstring docsPath(GetDocumentsFolderPath());
+
+	if (force)
+		outputPrintf(L"\n");
+
+	if (docsPath.empty())
+	{
+		outputPrintf( L"Failed to copy WPA profile to documents. See debugger output for details.\n" );
+		return;
+	}
+
+	const std::wstring source = docsPath + kWPAStartupFileName;
+	const std::wstring destDir = docsPath + std::wstring(L"\\WPA Files");
+	const std::wstring dest = destDir + kWPAStartupFileName;
+	const BOOL destinationExists = ::PathFileExistsW(dest.c_str());
+	if (force || !destinationExists)
+	{
+		ATLVERIFY(::CreateDirectoryW(destDir.c_str(), NULL));
+		const BOOL copyResult = ::CopyFileW(source.c_str(), dest.c_str(), FALSE);
+		if (copyResult)
+		{
+			if (force)
+				outputPrintf(L"Copied Startup.wpaProfile to the WPA Files directory.\n");
+			return;
+		}
+		if (force)
+		{
+			outputPrintf(L"Failed to copy Startup.wpaProfile to the WPA Files directory.\n");
+			outputLastError();
+			return;
+		}
+	}
+}
+
+void copyWPAProfileToLocalAppData(const std::wstring& exeDir, const bool force)
+{
+	PCWSTR const localAppDataEnvVar = L"localappdata";
+	// Then copy the WPA 10 startup.wpaProfile file
+	const std::wstring localAppData = GetEnvironmentVariableString(localAppDataEnvVar);
+	if (localAppData.empty())
+	{
+		outputPrintf(L"the `%s` environment variable didn't contain a valid path. Failed to copy WPA 10 profile.\n", localAppDataEnvVar);
+		return;
+	}
+	std::wstring source = exeDir + L"\\startup10.wpaProfile";
+	std::wstring destDir = std::wstring(localAppData) + L"\\Windows Performance Analyzer";
+	std::wstring dest = destDir + kWPAStartupFileName;
+	if (force || !::PathFileExistsW(dest.c_str()))
+	{
+
+		ATLVERIFY(::CreateDirectoryW(destDir.c_str(), NULL));
+
+		if (::CopyFileW(source.c_str(), dest.c_str(), FALSE))
+		{
+			if (force)
+				outputPrintf(L"%s", L"Copied Startup.10wpaProfile to %localappdata%\\Windows Performance Analyzer\n");
+			return;
+		}
+		if (force)
+		{
+			outputPrintf(L"%s", L"Failed to copy Startup.10wpaProfile to %localappdata%\\Windows Performance Analyzer\n");
+			outputLastError();
+		}
+	}
+
+}
+} //namespace {
+
+void outputLastError(const DWORD lastErr)
+{
+	const DWORD errMsgSize = 1024u;
+	wchar_t errBuff[errMsgSize] = {0};
+	const DWORD ret = ::FormatMessageW(
+		(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS),
+		NULL, lastErr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		errBuff, errMsgSize, NULL);
+
+	if (ret == 0)
+		std::terminate();//FormatMessageW failed.
+	outputPrintf(errBuff);
+}
+
+void debugLastError(const DWORD lastErr)
+{
+	const DWORD errMsgSize = 1024u;
+	wchar_t errBuff[errMsgSize] = {0};
+	const DWORD ret = ::FormatMessageW(
+		(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS),
+		NULL, lastErr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		errBuff, errMsgSize, NULL);
+
+	if (ret == 0)
+		std::terminate();//FormatMessageW failed.
+	debugPrintf(L"UIforETW encountered an error: %s\r\n", errBuff);
+}
+
+std::vector<std::wstring> split(const std::wstring& s, const char c)
 {
 	std::wstring::size_type i = 0;
 	std::wstring::size_type j = s.find(c);
@@ -40,26 +166,35 @@ std::vector<std::wstring> split(const std::wstring& s, char c)
 	return result;
 }
 
-std::vector<std::wstring> GetFileList(const std::wstring& pattern, bool fullPaths)
+std::vector<std::wstring> GetFileList(const std::wstring& pattern, const bool fullPaths)
 {
-	std::wstring directory;
-	if (fullPaths)
-		directory = GetDirPart(pattern);
+	const std::wstring directory = (fullPaths ? GetDirPart( pattern ) : L"");
+
+	//may not pass an empty string to FindFirstFileEx
+	UIETWASSERT(pattern.length() > 0);
+
+	//string passed to FindFirstFileEx must not end in a backslash
+	UIETWASSERT(pattern.back() != L'\\');
+
 	WIN32_FIND_DATA findData;
-	HANDLE hFindFile = FindFirstFileEx(pattern.c_str(), FindExInfoStandard,
+	HANDLE hFindFile = ::FindFirstFileExW(pattern.c_str(), FindExInfoBasic,
 				&findData, FindExSearchNameMatch, NULL, 0);
 
 	std::vector<std::wstring> result;
-	if (hFindFile != INVALID_HANDLE_VALUE)
+	if (hFindFile == INVALID_HANDLE_VALUE)
 	{
-		do
-		{
-			result.emplace_back(directory + findData.cFileName);
-		} while (FindNextFile(hFindFile, &findData));
-
-		FindClose(hFindFile);
+		//If there are NO matching files, then FindFirstFileExW returns
+		//INVALID_HANDLE_VALUE and the last error is ERROR_FILE_NOT_FOUND.
+		UIETWASSERT(::GetLastError() == ERROR_FILE_NOT_FOUND);
+		return result;
 	}
+	do
+	{
+		result.emplace_back(directory + findData.cFileName);
+	} while (::FindNextFileW(hFindFile, &findData));
 
+	UIETWASSERT(::GetLastError() == ERROR_NO_MORE_FILES);
+	ATLVERIFY(::FindClose(hFindFile));
 	return result;
 }
 
@@ -67,27 +202,42 @@ std::vector<std::wstring> GetFileList(const std::wstring& pattern, bool fullPath
 // an embedded NUL then the resulting string will be truncated.
 std::wstring LoadFileAsText(const std::wstring& fileName)
 {
+	if (!::PathFileExistsW(fileName.c_str()))
+		return L"";
+
 	std::ifstream f;
 	f.open(fileName, std::ios_base::binary);
 	if (!f)
+	{
+		outputPrintf(L"Failed to load file `%s` as text - f.open failed!\n", fileName.c_str());
 		return L"";
-
+	}
 	// Find the file length.
 	f.seekg(0, std::ios_base::end);
-	size_t length = (size_t)f.tellg();
+	const std::streamoff len_int = f.tellg();
+	if ( len_int == -1 )
+	{
+		outputPrintf(L"Failed to load file `%s` as text - f.tellg failed!\n", fileName.c_str());
+		return L"";
+	}
+	const size_t length = static_cast<size_t>(len_int);
 	f.seekg(0, std::ios_base::beg);
 
 	// Allocate a buffer and read the file.
 	std::vector<char> data(length + 2);
 	f.read(&data[0], length);
 	if (!f)
+	{
+		outputPrintf(L"Failed to load file `%s` as text - f.read failed!\n", fileName.c_str());
 		return L"";
+	}
 
 	// Add a multi-byte null terminator.
 	data[length] = 0;
 	data[length+1] = 0;
 
 	const wchar_t bom = 0xFEFF;
+	UIETWASSERT(data.size( ) > sizeof(bom));
 	if (memcmp(&bom, &data[0], sizeof(bom)) == 0)
 	{
 		// Assume UTF-16, strip bom, and return.
@@ -97,7 +247,6 @@ std::wstring LoadFileAsText(const std::wstring& fileName)
 	// If not-UTF-16 then convert from ANSI to wstring and return
 	return AnsiToUnicode(&data[0]);
 }
-
 
 void WriteTextAsFile(const std::wstring& fileName, const std::wstring& text)
 {
@@ -127,71 +276,125 @@ std::wstring ConvertToCRLF(const std::wstring& input)
 		if (c != '\r')
 			result += c;
 	}
-
 	return result;
 }
 
-void SetRegistryDWORD(HKEY root, const std::wstring& subkey, const std::wstring& valueName, DWORD value)
+void SetRegistryDWORD(const HKEY root, const std::wstring& subkey, const std::wstring& valueName, const DWORD value)
 {
 	HKEY key;
-	LONG result = RegOpenKeyEx(root, subkey.c_str(), 0, KEY_ALL_ACCESS, &key);
-	if (result == ERROR_SUCCESS)
-	{
-		RegSetValueEx(key, valueName.c_str(), 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value));
-		RegCloseKey(key);
-	}
+	ATLVERIFY(::RegOpenKeyExW(root, subkey.c_str(), 0, KEY_ALL_ACCESS, &key) == ERROR_SUCCESS);
+	ATLVERIFY(ERROR_SUCCESS == ::RegSetValueExW(key, valueName.c_str(), 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value)));
+	ATLVERIFY(::RegCloseKey(key) == ERROR_SUCCESS);
 }
 
-void CreateRegistryKey(HKEY root, const std::wstring& subkey, const std::wstring& newKey)
+void CreateRegistryKey(const HKEY root, const std::wstring& subkey, const std::wstring& newKey)
 {
 	HKEY key;
-	LONG result = RegOpenKeyEx(root, subkey.c_str(), 0, KEY_ALL_ACCESS, &key);
-	if (result == ERROR_SUCCESS)
+	ATLVERIFY(::RegOpenKeyExW(root, subkey.c_str(), 0, KEY_ALL_ACCESS, &key) == ERROR_SUCCESS);
+
+	HKEY resultKey;
+	//TODO: RegCreateKey is depreciated.
+	const LONG createResult = ::RegCreateKeyW(key, newKey.c_str(), &resultKey);
+	UIETWASSERT(createResult == ERROR_SUCCESS);
+	if (createResult == ERROR_SUCCESS)
 	{
-		HKEY resultKey;
-		result = RegCreateKey(key, newKey.c_str(), &resultKey);
-		if (result == ERROR_SUCCESS)
-		{
-			RegCloseKey(resultKey);
-		}
-		RegCloseKey(key);
+		ATLVERIFY(::RegCloseKey(resultKey) == ERROR_SUCCESS);
 	}
+
+	ATLVERIFY(::RegCloseKey(key) == ERROR_SUCCESS);
 }
 
-std::wstring GetEditControlText(HWND hEdit)
+std::wstring GetEditControlText(const HWND hEdit)
 {
-	std::wstring result;
-	int length = GetWindowTextLength(hEdit);
+	const int length = ::GetWindowTextLengthW(hEdit);
 	std::vector<wchar_t> buffer(length + 1);
-	GetWindowText(hEdit, &buffer[0], static_cast<int>(buffer.size()));
+
+	//GetWindowText https://msdn.microsoft.com/en-us/library/windows/desktop/ms633520.aspx
+	//If [GetWindowTextW] succeeds, the return value is the length,
+	//in characters, of the copied string, not including the
+	//terminating null character.
+
+	//If the window has no title bar or text,
+	//[or] if the title bar is empty,
+	//or if the window or control handle is invalid,
+	//the return value is zero. 
+
+	const int charsWritten = ::GetWindowTextW(hEdit, &buffer[0], static_cast<int>(buffer.size()));
+	if (charsWritten == 0)
+	{
+		if (length > 0)
+			debugLastError();
+		return L"";
+	}
+	UIETWASSERT(charsWritten == length);
+	UIETWASSERT((charsWritten) < (int)buffer.size());
+	UIETWASSERT(buffer[charsWritten] == 0);
 	// Double-verify that the buffer is null-terminated.
 	buffer[buffer.size() - 1] = 0;
 	return &buffer[0];
 }
 
+//MultiByteToWideChar: https://msdn.microsoft.com/en-us/library/windows/desktop/dd319072.aspx
+//
+//Remarks:
+//As mentioned in the caution above,
+//the output buffer can easily be overrun
+//if this function is not first called with cchWideChar set to 0
+//in order to obtain the required size. 
+int RequiredNumberOfWideChars(const std::string& text)
+{
+	static_assert( sizeof(std::string::value_type) == 1 == sizeof(text[0]),
+		"bad assumptions!");
+
+	const int multiCharCount = ::MultiByteToWideChar(CP_ACP, 0, text.c_str(),
+		static_cast<int>(text.size() + 1), NULL, 0);
+
+	if (multiCharCount == 0)
+	{
+		//No reasonable way for MultiByteToWideChar to fail.
+		debugLastError( );
+		std::terminate( );
+	}
+	UIETWASSERT(multiCharCount > 0);
+	return multiCharCount;
+}
+
 std::wstring AnsiToUnicode(const std::string& text)
 {
+	//if the string is empty, then we can return early, and avoid
+	//confusing return values (from MultiByteToWideChar)
+	if (text.empty())
+		return L"";
+
 	// Determine number of wide characters to be allocated for the
 	// Unicode string.
-	size_t cCharacters = text.size() + 1;
+	const int multiCharCount = RequiredNumberOfWideChars(text);
 
-	std::vector<wchar_t> buffer(cCharacters);
+	std::vector<wchar_t> buffer(multiCharCount);
 
 	// Convert to Unicode.
-	std::wstring result;
-	if (MultiByteToWideChar(CP_ACP, 0, text.c_str(), static_cast<int>(cCharacters), &buffer[0], static_cast<int>(cCharacters)))
+	const int multiToWideResult = ::MultiByteToWideChar(
+		CP_ACP, 0, text.c_str(), static_cast<int>(text.size() + 1),
+		&buffer[0], multiCharCount);
+
+	if (multiToWideResult == 0)
 	{
-		// Double-verify that the buffer is null-terminated.
-		buffer[buffer.size() - 1] = 0;
-		result = &buffer[0];
-		return result;
+		//No reasonable way for MultiByteToWideChar to fail.
+		debugLastError( );
+		std::terminate( );
 	}
 
+	UIETWASSERT(multiToWideResult > 0);
+	UIETWASSERT(buffer[multiToWideResult - 1] == 0);
+
+	// Double-verify that the buffer is null-terminated.
+	buffer.at(buffer.size() - 1) = 0;
+	std::wstring result = &buffer[0];
 	return result;
 }
 
 // Return a string from a format string and some printf-style arguments.
-std::wstring stringPrintf(_Printf_format_string_ const wchar_t* pFormat, ...)
+std::wstring stringPrintf(_Printf_format_string_ PCWSTR const pFormat, ...)
 {
 	va_list args;
 	va_start(args, pFormat);
@@ -203,7 +406,7 @@ std::wstring stringPrintf(_Printf_format_string_ const wchar_t* pFormat, ...)
 }
 
 // Call OutputDebugString with a format string and some printf-style arguments.
-void debugPrintf(_Printf_format_string_ const wchar_t* pFormat, ...)
+void debugPrintf(_Printf_format_string_ PCWSTR const pFormat, ...)
 {
 	va_list args;
 	va_start(args, pFormat);
@@ -211,41 +414,41 @@ void debugPrintf(_Printf_format_string_ const wchar_t* pFormat, ...)
 	wchar_t buffer[1024];
 	_vsnwprintf_s(buffer, _TRUNCATE, pFormat, args);
 	va_end(args);
-	OutputDebugString(buffer);
+	OutputDebugStringW(buffer);
 }
 
 // Get the next/previous dialog item (next/prev in window order and tab order) allowing
 // for disabled controls, invisible controls, and wrapping at the end of the tab order.
 
-static bool ControlOK(HWND win)
+static bool ControlOK(const HWND win)
 {
 	if (!win)
 		return false;
-	if (!IsWindowEnabled(win))
+	if (!::IsWindowEnabled(win))
 		return false;
-	if (!(GetWindowLong(win, GWL_STYLE) & WS_TABSTOP))
+	if (!(::GetWindowLong(win, GWL_STYLE) & WS_TABSTOP))
 		return false;
 	// You have to check for visibility of the parent window because during dialog
 	// creation the parent window is invisible, which renders the child windows
 	// all invisible - not good.
-	HWND parent = GetParent(win);
+	const HWND parent = ::GetParent(win);
 	UIETWASSERT(parent);
-	if (!IsWindowVisible(win) && IsWindowVisible(parent))
+	if (!::IsWindowVisible(win) && ::IsWindowVisible(parent))
 		return false;
 	return true;
 }
 
-static HWND GetNextDlgItem(HWND win, bool Wrap)
+static HWND GetNextDlgItem(const HWND win, const bool Wrap)
 {
-	HWND next = GetWindow(win, GW_HWNDNEXT);
-	while (next != win && !ControlOK(next))
+	HWND next = ::GetWindow(win, GW_HWNDNEXT);
+	while ((next != win) && (!::ControlOK(next)))
 	{
 		if (next)
-			next = GetWindow(next, GW_HWNDNEXT);
+			next = ::GetWindow(next, GW_HWNDNEXT);
 		else
 		{
 			if (Wrap)
-				next = GetWindow(win, GW_HWNDFIRST);
+				next = ::GetWindow(win, GW_HWNDFIRST);
 			else
 				return 0;
 		}
@@ -255,22 +458,23 @@ static HWND GetNextDlgItem(HWND win, bool Wrap)
 }
 
 _Pre_satisfies_(Win != NULL)
-void SmartEnableWindow(HWND Win, BOOL Enable)
+void SmartEnableWindow(const HWND Win, const BOOL Enable)
 {
 	UIETWASSERT(Win);
 	if (!Enable)
 	{
-		HWND hasfocus = GetFocus();
 		bool FocusProblem = false;
-		HWND focuscopy;
-		for (focuscopy = hasfocus; focuscopy; focuscopy = (GetParent)(focuscopy))
+		for (HWND focuscopy = ::GetFocus(); focuscopy; focuscopy = ::GetParent(focuscopy))
+		{
 			if (focuscopy == Win)
 				FocusProblem = true;
+		}
+
 		if (FocusProblem)
 		{
-			HWND nextctrl = GetNextDlgItem(Win, true);
+			HWND nextctrl = ::GetNextDlgItem(Win, true);
 			if (nextctrl)
-				SetFocus(nextctrl);
+				::SetFocus(nextctrl);
 		}
 	}
 	::EnableWindow(Win, Enable);
@@ -278,59 +482,64 @@ void SmartEnableWindow(HWND Win, BOOL Enable)
 
 std::wstring GetFilePart(const std::wstring& path)
 {
-	const wchar_t* pLastSlash = wcsrchr(path.c_str(), '\\');
-	if (pLastSlash)
-		return pLastSlash + 1;
+	UIETWASSERT(path.size() > 0);
+	const size_t lastSlash = path.find_last_of( L'\\' );
+	if (lastSlash != std::wstring::npos)
+		return path.substr(lastSlash);
 	// If there's no slash then the file part is the entire string.
 	return path;
 }
 
 std::wstring GetFileExt(const std::wstring& path)
 {
-	std::wstring filePart = GetFilePart(path);
-	const wchar_t* pLastPeriod = wcsrchr(filePart.c_str(), '.');
-	if (pLastPeriod)
-		return pLastPeriod;
+	const std::wstring filePart = GetFilePart(path);
+	const size_t lastPeriod = filePart.find_last_of( L'.' );
+	if (lastPeriod != std::wstring::npos)
+		return filePart.substr(lastPeriod);
+	// If there's no period then there's no extension.
 	return L"";
 }
 
 std::wstring GetDirPart(const std::wstring& path)
 {
-	const wchar_t* pLastSlash = wcsrchr(path.c_str(), '\\');
-	if (pLastSlash)
-		return path.substr(0, pLastSlash + 1 - path.c_str());
+	UIETWASSERT(path.size() > 0);
+	const size_t lastSlash = path.find_last_of( L'\\' );
+	if (lastSlash != std::wstring::npos)
+	{
+		UIETWASSERT(path.at( lastSlash ) != path.back());
+		return path.substr(0, lastSlash+1);
+	}
 	// If there's no slash then there is no directory.
 	return L"";
 }
 
 std::wstring CrackFilePart(const std::wstring& path)
 {
-	std::wstring filePart = GetFilePart(path);
+	const std::wstring filePart = GetFilePart(path);
 	const std::wstring extension = GetFileExt(filePart);
+	UIETWASSERT(filePart.size() >= extension.size());
 	if (!extension.empty())
-	{
-		filePart = filePart.substr(0, filePart.size() - extension.size());
-	}
-
+		return filePart.substr(0, filePart.size() - extension.size());
 	return filePart;
 }
 
 std::wstring StripExtensionFromPath(const std::wstring& path)
 {
-	std::wstring ext = GetFileExt(path);
+	UIETWASSERT(path.size() > 0);
+	const std::wstring ext = GetFileExt(path);
+	UIETWASSERT(path.size() >= ext.size());
 	return path.substr(0, path.size() - ext.size());
 }
 
-int DeleteOneFile(HWND hwnd, const std::wstring& path)
+int DeleteOneFile(const HWND hwnd, const std::wstring& path)
 {
-	std::vector<std::wstring> paths;
-	paths.emplace_back(path);
-	return DeleteFiles(hwnd, paths);
+	//{path} uses std::vector list initialization
+	return DeleteFiles(hwnd, {path});
 }
 
-int DeleteFiles(HWND hwnd, const std::vector<std::wstring>& paths)
+int DeleteFiles(const HWND hwnd, const std::vector<std::wstring>& paths)
 {
-	ATLASSERT(paths.size() > 0);
+	UIETWASSERT(paths.size() > 0);
 
 	std::vector<wchar_t> fileNames;
 	for (const auto& path : paths)
@@ -349,78 +558,83 @@ int DeleteFiles(HWND hwnd, const std::vector<std::wstring>& paths)
 		FO_DELETE,
 		&fileNames[0],
 		NULL,
-		FOF_ALLOWUNDO | FOF_FILESONLY | FOF_NOCONFIRMATION,
+		(FOF_ALLOWUNDO | FOF_FILESONLY | FOF_NOCONFIRMATION),
 	};
 	// Delete using the recycle bin.
-	int result = SHFileOperation(&fileOp);
-
-	return result;
+	//TODO: IFileOperation?
+	return ::SHFileOperationW(&fileOp);
 }
 
 void SetClipboardText(const std::wstring& text)
 {
-	BOOL cb = OpenClipboard(GetDesktopWindow());
-	if (!cb)
-		return;
+	ATLVERIFY(::OpenClipboard(::GetDesktopWindow()));
+	ATLVERIFY(::EmptyClipboard());
 
-	EmptyClipboard();
-
-	size_t length = (text.size() + 1) * sizeof(wchar_t);
-	HANDLE hmem = GlobalAlloc(GMEM_MOVEABLE, length);
-	if (hmem)
+	const size_t length = (text.size() + 1) * sizeof(text[0]);
+	HANDLE hmem = ::GlobalAlloc(GMEM_MOVEABLE, length);
+	if (!hmem)
 	{
-		void *ptr = GlobalLock(hmem);
-		if (ptr != NULL)
-		{
-			memcpy(ptr, text.c_str(), length);
-			GlobalUnlock(hmem);
-
-			SetClipboardData(CF_UNICODETEXT, hmem);
-		}
+		ATLVERIFY(::CloseClipboard());
+		return;
 	}
 
-	CloseClipboard();
+	void* const ptr = ::GlobalLock(hmem);
+	UIETWASSERT(ptr != NULL);
+
+	wcscpy_s(static_cast<wchar_t*>(ptr), (text.size() + 1), text.c_str());
+
+	UnlockGlobalMemory(hmem);
+	if (::SetClipboardData(CF_UNICODETEXT, hmem) == NULL)
+	{
+		ATLVERIFY(!::GlobalFree(hmem));
+		ATLVERIFY(::CloseClipboard());
+		return;
+	}
+	ATLVERIFY(::CloseClipboard());
 }
 
 std::wstring GetClipboardText()
 {
+	ATLVERIFY(::OpenClipboard(::GetDesktopWindow()));
 	std::wstring result;
-	BOOL cb = OpenClipboard(GetDesktopWindow());
-	if (!cb)
-		return result;
 
-	HANDLE hClip = GetClipboardData(CF_UNICODETEXT);
-	if (hClip)
+	HANDLE hClip = ::GetClipboardData(CF_UNICODETEXT);
+	UIETWASSERT(hClip);
+
+	void* const ptr = ::GlobalLock(hClip);
+	UIETWASSERT(ptr != NULL);
+	const size_t bytes = ::GlobalSize(hClip);
+	if (bytes == 0)
 	{
-		wchar_t *text = static_cast<wchar_t *>(GlobalLock(hClip));
-		if (text)
-		{
-			size_t bytes = GlobalSize(hClip);
-			result.insert(result.begin(), text, text + bytes / sizeof(wchar_t));
-		}
-		::GlobalUnlock(hClip);
+		UnlockGlobalMemory(hClip);
+		ATLVERIFY(::CloseClipboard());
+		return result;
 	}
-
-	CloseClipboard();
-
+	PCWSTR const text = static_cast<PCWSTR>(ptr);
+	result.insert(result.begin(), text, text + (bytes / sizeof(text[0])));
+	UnlockGlobalMemory(hClip);
+	ATLVERIFY(::CloseClipboard());
 	return result;
 }
 
 int64_t GetFileSize(const std::wstring& path)
 {
-	LARGE_INTEGER result;
-	HANDLE hFile = CreateFile(path.c_str(), GENERIC_READ,
-		FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
+	LARGE_INTEGER result = {0};
+	HANDLE hFile = ::CreateFileW(path.c_str(), GENERIC_READ,
+		(FILE_SHARE_READ | FILE_SHARE_WRITE), NULL, OPEN_EXISTING,
 		FILE_ATTRIBUTE_NORMAL, NULL);
-	if (hFile == INVALID_HANDLE_VALUE)
-		return 0;
 
-	if (GetFileSizeEx(hFile, &result))
+	if (hFile == INVALID_HANDLE_VALUE)
 	{
-		CloseHandle(hFile);
-		return result.QuadPart;
+		debugPrintf(L"Failed to get file size!\n");
+		debugLastError();
+		return 0;
 	}
-	CloseHandle(hFile);
+
+	const BOOL gfsResult = ::GetFileSizeEx(hFile, &result);
+	CloseValidHandle(hFile);
+	if (gfsResult)
+		return result.QuadPart;
 	return 0;
 }
 
@@ -431,108 +645,117 @@ bool Is64BitWindows()
 #else
 	// http://blogs.msdn.com/b/oldnewthing/archive/2005/02/01/364563.aspx
 	BOOL f64 = FALSE;
-	bool bIsWin64 = IsWow64Process(GetCurrentProcess(), &f64) && f64;
-	return bIsWin64;
+	return ::IsWow64Process(::GetCurrentProcess(), &f64) && f64;
 #endif
 }
 
 bool Is64BitBuild()
 {
+	//when MSVC gets constexpr, this is a perfect candidate.
 	return sizeof(void*) == 8;
 }
 
-WindowsVersion GetWindowsVersion()
+bool IsWindowsTenOrGreater()
 {
-	OSVERSIONINFO verInfo = { sizeof(OSVERSIONINFO) };
-	// warning C4996: 'GetVersionExA': was declared deprecated
-	// warning C28159: Consider using 'IsWindows*' instead of 'GetVersionExW'.Reason : Deprecated.Use VerifyVersionInfo* or IsWindows* macros from VersionHelpers.
-#pragma warning(suppress : 4996)
-#pragma warning(suppress : 28159)
-	GetVersionEx(&verInfo);
-
-	// Windows 10 preview has major version 10, if you have a compatibility
-	// manifest for that OS, which this program should have.
-	if (verInfo.dwMajorVersion > 6)
-		return kWindowsVersion10;	// Or higher, I guess.
-
-	// Windows 8.1 will only be returned if there is an appropriate
-	// compatibility manifest.
-	if (verInfo.dwMajorVersion == 6 && verInfo.dwMinorVersion >= 3)
-		return kWindowsVersion8_1;
-
-	if (verInfo.dwMajorVersion == 6 && verInfo.dwMinorVersion >= 2)
-		return kWindowsVersion8;
-
-	if (verInfo.dwMajorVersion == 6 && verInfo.dwMinorVersion >= 1)
-		return kWindowsVersion7;
-
-	if (verInfo.dwMajorVersion == 6)
-		return kWindowsVersionVista;
-
-	return kWindowsVersionXP;
+	return IsWindowsVersionOrGreater(10, 0, 0);
 }
 
+bool IsWindowsXPOrLesser()
+{
+	return !IsWindowsVistaOrGreater();
+}
 
+bool IsWindowsSevenOrLesser()
+{
+	return !IsWindows8OrGreater();
+}
+
+bool IsWindowsVistaOrLesser()
+{
+	return !IsWindows7OrGreater();
+}
+
+std::wstring GetEnvironmentVariableString(_In_z_ PCWSTR const variable)
+{
+	const rsize_t bufferSize = 512u;
+	wchar_t buffer[bufferSize] = {0};
+	rsize_t sizeRequired = 0u;
+	const errno_t result = _wgetenv_s(&sizeRequired, buffer, variable);
+	if (result == 0)
+		return buffer;
+	return L"";
+}
+
+std::string GetEnvironmentVariableString(_In_z_ PCSTR const variable)
+{
+	const rsize_t bufferSize = 512u;
+	char buffer[bufferSize] = {0};
+	rsize_t sizeRequired = 0u;
+	const errno_t result = getenv_s(&sizeRequired, buffer, variable);
+	if (result == 0)
+		return buffer;
+	return "";
+}
 
 std::wstring FindPython()
 {
-#pragma warning(suppress:4996)
-	PCWSTR const pytwoseven = _wgetenv( L"python27" );
+	const std::wstring pytwoseven = GetEnvironmentVariableString( L"python27" );
 	
 	//Some people, like me, (Alexander Riccio) have an environment variable 
 	//that specifically points to Python 2.7.
 	//As a workaround for issue #13, we'll use that version of Python.
 	//See the issue: https://github.com/google/UIforETW/issues/13
-	if ( pytwoseven )
-	{
+	if ( !pytwoseven.empty() )
 		return pytwoseven;
+	const std::wstring path = GetEnvironmentVariableString(L"path");
+	if (path.empty())
+	{
+		// No python found.
+		return L"";
 	}
 
-#pragma warning(suppress:4996)	
-	const wchar_t* path = _wgetenv(L"path");
-	if (path)
+	const std::vector<std::wstring> pathParts = split(path, ';');
+	// First look for python.exe. If that isn't found then look for
+	// python.bat, part of Chromium's depot_tools
+	for (const auto& exeName : { L"\\python.exe", L"\\python.bat" })
 	{
-		std::vector<std::wstring> pathParts = split(path, ';');
-		// First look for python.exe. If that isn't found then look for
-		// python.bat, part of Chromium's depot_tools
-		for (const auto& exeName : { L"\\python.exe", L"\\python.bat" })
+		for (const auto& part : pathParts)
 		{
-			for (const auto& part : pathParts)
-			{
-				std::wstring pythonPath = part + exeName;
-				if (PathFileExists(pythonPath.c_str()))
-				{
-					return pythonPath;
-				}
-			}
+			const std::wstring pythonPath = part + exeName;
+			if (::PathFileExistsW(pythonPath.c_str()))
+				return pythonPath;
 		}
 	}
 	// No python found.
 	return L"";
 }
 
-std::wstring GetBuildTimeFromAddress(void* codeAddress)
+std::wstring GetBuildTimeFromAddress(_In_ const void* const codeAddress)
 {
 	// Get the base of the address reservation. This lets this
 	// function be passed any function or global variable address
 	// in a DLL or EXE.
-	MEMORY_BASIC_INFORMATION	memoryInfo;
-	if (VirtualQuery(codeAddress, &memoryInfo, sizeof(memoryInfo)) != sizeof(memoryInfo))
+
+	//https://msdn.microsoft.com/en-us/library/windows/desktop/aa366902.aspx
+	//If the function fails, the return value is zero.
+	MEMORY_BASIC_INFORMATION memoryInfo = {0};
+	if (::VirtualQuery(codeAddress, &memoryInfo, sizeof(memoryInfo)) != sizeof(memoryInfo))
 	{
 		UIETWASSERT(0);
 		return L"";
 	}
-	void* ModuleHandle = memoryInfo.AllocationBase;
+	const void* const ModuleHandle = memoryInfo.AllocationBase;
 
 	// Walk the PE data structures to find the link time stamp.
-	IMAGE_DOS_HEADER *DosHeader = (IMAGE_DOS_HEADER*)ModuleHandle;
+	const IMAGE_DOS_HEADER* const DosHeader = reinterpret_cast<const IMAGE_DOS_HEADER*>(ModuleHandle);
 	if (IMAGE_DOS_SIGNATURE != DosHeader->e_magic)
 	{
 		UIETWASSERT(0);
 		return L"";
 	}
-	IMAGE_NT_HEADERS *NTHeader = (IMAGE_NT_HEADERS*)((char *)DosHeader
-		+ DosHeader->e_lfanew);
+	const IMAGE_NT_HEADERS* const NTHeader = 
+		reinterpret_cast<const IMAGE_NT_HEADERS*>(
+			reinterpret_cast<const char*>(DosHeader) + DosHeader->e_lfanew);
 	if (IMAGE_NT_SIGNATURE != NTHeader->Signature)
 	{
 		UIETWASSERT(0);
@@ -547,9 +770,9 @@ std::wstring GetBuildTimeFromAddress(void* codeAddress)
 	// Print out the module information. The %.24s is necessary to trim
 	// the new line character off of the date string returned by asctime().
 	// _wasctime_s requires a 26-character buffer.
-	wchar_t ascTimeBuf[26];
+	wchar_t ascTimeBuf[26] = {0};
 	_wasctime_s(ascTimeBuf, &linkTime);
-	wchar_t	buffer[100];
+	wchar_t	buffer[100] = {0};
 	swprintf_s(buffer, L"%.24s GMT (%08lx)", ascTimeBuf, NTHeader->FileHeader.TimeDateStamp);
 	// Return buffer+4 because we don't need the day of the week.
 	return buffer + 4;
@@ -557,7 +780,7 @@ std::wstring GetBuildTimeFromAddress(void* codeAddress)
 
 std::wstring GetEXEBuildTime()
 {
-	HMODULE ModuleHandle = GetModuleHandle(nullptr);
+	const HMODULE ModuleHandle = ::GetModuleHandle(nullptr);
 	return GetBuildTimeFromAddress(ModuleHandle);
 }
 
@@ -582,18 +805,18 @@ typedef struct tagTHREADNAME_INFO
 // warning C6320 : Exception - filter expression is the constant EXCEPTION_EXECUTE_HANDLER.This might mask exceptions that were not intended to be handled.
 // warning C6322 : Empty _except block.
 
-void SetCurrentThreadName(PCSTR threadName)
+void SetCurrentThreadName(PCSTR const threadName)
 {
-	const DWORD dwThreadID = GetCurrentThreadId();
-	THREADNAME_INFO info;
-	info.dwType = 0x1000;
-	info.szName = threadName;
-	info.dwThreadID = dwThreadID;
-	info.dwFlags = 0;
-
+	const DWORD dwThreadID = ::GetCurrentThreadId();
+	const THREADNAME_INFO info = { 0x1000, threadName, dwThreadID, 0 };
 	__try
 	{
-		RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
+		const DWORD numArguments = sizeof(info) / sizeof(ULONG_PTR);
+		static_assert(
+			numArguments <= EXCEPTION_MAXIMUM_PARAMETERS,
+			"This value must not exceed EXCEPTION_MAXIMUM_PARAMETERS.");
+
+		::RaiseException(MS_VC_EXCEPTION, 0, numArguments, reinterpret_cast<const ULONG_PTR*>(&info));
 	}
 	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
@@ -601,70 +824,16 @@ void SetCurrentThreadName(PCSTR threadName)
 }
 #pragma warning(pop)
 
-
-void CopyStartupProfiles(const std::wstring& exeDir, bool force)
+void CopyStartupProfiles(const std::wstring& exeDir, const bool force)
 {
-	const wchar_t* fileName = L"\\Startup.wpaProfile";
 
-	// First copy the WPA 8.1 startup.wpaProfile file
-	wchar_t documents[MAX_PATH];
-	const BOOL getMyDocsResult = SHGetSpecialFolderPathW(NULL, documents, CSIDL_MYDOCUMENTS, TRUE);
-	UIETWASSERT(getMyDocsResult);
-	if (force)
-		outputPrintf(L"\n");
-	if (getMyDocsResult)
-	{
-		std::wstring source = exeDir + fileName;
-		std::wstring destDir = documents + std::wstring(L"\\WPA Files");
-		std::wstring dest = destDir + fileName;
-		if (force || !PathFileExists(dest.c_str()))
-		{
-			(void)_wmkdir(destDir.c_str());
-			if (CopyFile(source.c_str(), dest.c_str(), FALSE))
-			{
-				if (force)
-					outputPrintf(L"Copied Startup.wpaProfile to the WPA Files directory.\n");
-			}
-			else
-			{
-				if (force)
-					outputPrintf(L"Failed to copy Startup.wpaProfile to the WPA Files directory.\n");
-			}
-		}
-	}
+	// WPA 8.1 stores startup.wpaProfile file in Documents/WPA Files
+	copyWPAProfileToDocuments(force);
 
-	// Then copy the WPA 10 startup.wpaProfile file
-#pragma warning(suppress : 4996)
-	const wchar_t* localAppData = _wgetenv(L"localappdata");
-	if (localAppData)
-	{
-		std::wstring source = exeDir + L"\\startup10.wpaProfile";
-		std::wstring destDir = std::wstring(localAppData) + L"\\Windows Performance Analyzer";
-		std::wstring dest = destDir + fileName;
-		if (force || !PathFileExists(dest.c_str()))
-		{
-			(void)_wmkdir(destDir.c_str());
-			if (CopyFile(source.c_str(), dest.c_str(), FALSE))
-			{
-				if (force)
-					outputPrintf(L"%s", L"Copied Startup.10wpaProfile to %localappdata%\\Windows Performance Analyzer\n");
-			}
-			else
-			{
-				if (force)
-					outputPrintf(L"%s", L"Failed to copy Startup.10wpaProfile to %localappdata%\\Windows Performance Analyzer\n");
-			}
-		}
-	}
+	copyWPAProfileToLocalAppData(exeDir, force);
 }
 
-void CloseValidHandle( _Pre_valid_ _Post_ptr_invalid_ HANDLE handle )
+void CloseValidHandle(_In_ _Pre_valid_ _Post_ptr_invalid_ const HANDLE handle)
 {
-	const BOOL handleClosed = ::CloseHandle(handle);
-	if (handleClosed == 0)
-	{
-		std::terminate( );
-	}
-
+	ATLVERIFY(::CloseHandle(handle) != 0);
 }
-


### PR DESCRIPTION
Commit message below:
-----

Changes:
- Added lots of global scope qualifiers
- Added some const. See `ControlOK` (local variable `HWND parent`),
`SetCurrentThreadName` (local variable/argument to `::RaiseException`,
`THREADNAME_INFO`).
- Removed custom GetWindowsVersion, and replaced with
IsWindows*OrGreater variants
- Refactored CopyStartupProfiles
- Replaced `SHGetSpecialFolderPath` (depreciated) with
`SHGetKnownFolderPath`
- Added parenthesis for complex conditional expressions (see
`GetFileSize` and `GetNextDlgItem`)
- Added a comment to the call to `VirtualQuery` (with a link) that
documents the failure behavior, so it's clear that the `!=
sizeof(memoryInfo)` check is valid.
- Added a `static_assert` for the value of the third parameter to
`::RaiseException`, to statically check precondition.
- Replaced manual COM memory management in GetDocumentsFolderPath with
[ATL's built-in COM smart
pointer(`ATL::CComHeapPtr`)](https://msdn.microsoft.com/en-us/library/80zw33a6.aspx).
I hate operator overloading, so I explicitly reference the `m_pData`
member of `ATL::CComHeapPtr`, which is otherwise implicitly passed to
`::SHGetKnownFolderPath` via the `operator&` overload.

Details on the `SHGetSpecialFolderPath` depreciation:

SHGetSpecialFolderPath is NOT supported, as
(https://msdn.microsoft.com/en-us/library/windows/desktop/bb762204.aspx)
says:

```
[SHGetSpecialFolderPath is not supported. Instead, use ShGetFolderPath.]
```

... but SHGetFolderPath
(https://msdn.microsoft.com/en-us/library/windows/desktop/bb762181.aspx)
is *itself* depreciated, so I've refactored to use SHGetKnownFolderPath,
which is supported.