### PR TITLE
Add a tool to generate a flame graph from an ETW trace.

### DIFF
--- a/ETWInsights/ETWInsights.sln
+++ b/ETWInsights/ETWInsights.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "base", "base\base.vcxproj", "{637388CA-E6E9-4D38-8DC9-CC2FE937DE24}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "etw_reader", "etw_reader\etw_reader.vcxproj", "{E1FCFE0C-B8CB-4516-9F46-54C1F73A9601}"
+	ProjectSection(ProjectDependencies) = postProject
+		{637388CA-E6E9-4D38-8DC9-CC2FE937DE24} = {637388CA-E6E9-4D38-8DC9-CC2FE937DE24}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "flame_graph", "flame_graph\flame_graph.vcxproj", "{EE253535-588A-4ABC-A65E-8DE45E240D7F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{E1FCFE0C-B8CB-4516-9F46-54C1F73A9601} = {E1FCFE0C-B8CB-4516-9F46-54C1F73A9601}
+		{637388CA-E6E9-4D38-8DC9-CC2FE937DE24} = {637388CA-E6E9-4D38-8DC9-CC2FE937DE24}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{637388CA-E6E9-4D38-8DC9-CC2FE937DE24}.Debug|Win32.ActiveCfg = Debug|Win32
+		{637388CA-E6E9-4D38-8DC9-CC2FE937DE24}.Debug|Win32.Build.0 = Debug|Win32
+		{637388CA-E6E9-4D38-8DC9-CC2FE937DE24}.Release|Win32.ActiveCfg = Release|Win32
+		{637388CA-E6E9-4D38-8DC9-CC2FE937DE24}.Release|Win32.Build.0 = Release|Win32
+		{E1FCFE0C-B8CB-4516-9F46-54C1F73A9601}.Debug|Win32.ActiveCfg = Debug|Win32
+		{E1FCFE0C-B8CB-4516-9F46-54C1F73A9601}.Debug|Win32.Build.0 = Debug|Win32
+		{E1FCFE0C-B8CB-4516-9F46-54C1F73A9601}.Release|Win32.ActiveCfg = Release|Win32
+		{E1FCFE0C-B8CB-4516-9F46-54C1F73A9601}.Release|Win32.Build.0 = Release|Win32
+		{EE253535-588A-4ABC-A65E-8DE45E240D7F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{EE253535-588A-4ABC-A65E-8DE45E240D7F}.Debug|Win32.Build.0 = Debug|Win32
+		{EE253535-588A-4ABC-A65E-8DE45E240D7F}.Release|Win32.ActiveCfg = Release|Win32
+		{EE253535-588A-4ABC-A65E-8DE45E240D7F}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/ETWInsights/ETWInsights.vcxproj
+++ b/ETWInsights/ETWInsights.vcxproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E24EE5EB-D66E-4569-A1FE-E19C632E8764}</ProjectGuid>
+    <RootNamespace>ETWInsights</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/ETWInsights/ETWInsights.vcxproj.filters
+++ b/ETWInsights/ETWInsights.vcxproj.filters
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/ETWInsights/README.md
+++ b/ETWInsights/README.md
@@ -1,0 +1,23 @@
+# ETWInsights
+
+## flame_graph
+
+flame_graph is a command-line tool to generate a
+[flame graph](http://www.brendangregg.com/flamegraphs.html) from an ETW trace.
+
+Usage: `flame_graph.exe --trace trace_file_path [options]`
+
+Options:
+
+- `--process_name`: Only show stacks from processes with the specified name.
+- `--tid`: Only show stacks from the specified thread.
+- `--start_ts`: Only show stacks that occurred after the specified timestamp.
+- `--end_ts`: Only show stacks that occurred before the specified timestamp.
+- `--out`: Output file path. Default: flamegraph.txt
+
+Timestamps are a number of microseconds elapsed since the beginning of the
+trace.
+
+`flame_graph.exe` produces a text file that tells how much time was spent in
+each call stack. To convert this text file to a nice-looking SVG report, use
+this [perl script](https://github.com/brendangregg/FlameGraph/blob/master/flamegraph.pl).

--- a/ETWInsights/base/base.h
+++ b/ETWInsights/base/base.h
@@ -1,0 +1,23 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+// Macro to disable the copy constructor and assignment operator.
+// Must be placed with the private declarations of a class.
+#define DISALLOW_COPY_AND_ASSIGN(ClassType) \
+  ClassType(const ClassType&);              \
+  void operator=(const ClassType&)

--- a/ETWInsights/base/base.vcxproj
+++ b/ETWInsights/base/base.vcxproj
@@ -1,0 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{637388CA-E6E9-4D38-8DC9-CC2FE937DE24}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>base</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="base.h" />
+    <ClInclude Include="binary_search.h" />
+    <ClInclude Include="child_process.h" />
+    <ClInclude Include="command_line.h" />
+    <ClInclude Include="error_string.h" />
+    <ClInclude Include="file.h" />
+    <ClInclude Include="history.h" />
+    <ClInclude Include="logging.h" />
+    <ClInclude Include="numeric_conversions.h" />
+    <ClInclude Include="string_utils.h" />
+    <ClInclude Include="types.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="child_process.cc" />
+    <ClCompile Include="command_line.cc" />
+    <ClCompile Include="error_string.cc" />
+    <ClCompile Include="file.cc" />
+    <ClCompile Include="logging.cc" />
+    <ClCompile Include="numeric_conversions.cc" />
+    <ClCompile Include="string_utils.cc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/ETWInsights/base/base.vcxproj.filters
+++ b/ETWInsights/base/base.vcxproj.filters
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="base.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="binary_search.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="child_process.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="command_line.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="error_string.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="file.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="history.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="logging.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="numeric_conversions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="string_utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="types.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="child_process.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="command_line.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="error_string.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="file.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="logging.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="numeric_conversions.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="string_utils.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/ETWInsights/base/binary_search.h
+++ b/ETWInsights/base/binary_search.h
@@ -1,0 +1,45 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+namespace base {
+
+// Finds the last element of a vector that compares smaller or equal to |val|.
+// @param vec the vector in which to search.
+// @param val the value used for comparison.
+// @param comparator the comparison function or function object.
+// @returns an iterator to the last element of |vec| that is smaller or equal
+//    to |val|, of .end() if none exists.
+template <typename container_type,
+          typename comparison_value_type,
+          typename comparator_type>
+auto FindSmallerOrEqual(container_type& vec,
+                        comparison_value_type& val,
+                        comparator_type comparator) -> decltype(vec.begin()) {
+  auto it = std::upper_bound(vec.begin(), vec.end(), val, comparator);
+  if (it == vec.begin())
+    return vec.end();
+
+  --it;
+
+  return it;
+}
+
+}  // namespace base

--- a/ETWInsights/base/child_process.cc
+++ b/ETWInsights/base/child_process.cc
@@ -1,0 +1,118 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "base/child_process.h"
+#include "base/error_string.h"
+#include "base/logging.h"
+#include "base/string_utils.h"
+
+#include <vector>
+
+namespace base {
+
+ChildProcess::ChildProcess() {}
+
+ChildProcess::~ChildProcess() {
+  if (hProcess_) {
+    DWORD exitCode = GetExitCode();
+    if (exitCode)
+      LOG(ERROR) << "Process exit code was " << exitCode << std::endl;
+    CloseHandle(hProcess_);
+  }
+}
+
+_Pre_satisfies_(!(this->hProcess_)) bool ChildProcess::Run(
+    const std::wstring& command) {
+  DCHECK(!hProcess_);
+
+  if (output_path_.empty())
+    return false;
+
+  SECURITY_ATTRIBUTES security = {sizeof(security), 0, TRUE};
+
+  hStdOutput_ =
+      CreateFile(output_path_.c_str(), GENERIC_WRITE, 0, &security,
+                 CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, INVALID_HANDLE_VALUE);
+
+  if (hStdOutput_ == INVALID_HANDLE_VALUE)
+    return false;
+  if (!DuplicateHandle(GetCurrentProcess(), hStdOutput_, GetCurrentProcess(),
+                       &hStdError_, 0, TRUE, DUPLICATE_SAME_ACCESS)) {
+    return false;
+  }
+  // Keep Python happy by giving it a valid hStdInput handle.
+  if (!DuplicateHandle(GetCurrentProcess(), hStdOutput_, GetCurrentProcess(),
+                       &hStdInput_, 0, TRUE, DUPLICATE_SAME_ACCESS)) {
+    return false;
+  }
+
+  STARTUPINFO startupInfo = {};
+  startupInfo.hStdOutput = hStdOutput_;
+  startupInfo.hStdError = hStdError_;
+  startupInfo.hStdInput = hStdInput_;
+  startupInfo.dwFlags = STARTF_USESTDHANDLES;
+
+  PROCESS_INFORMATION processInfo = {};
+  DWORD flags = CREATE_NO_WINDOW;
+  // Wacky CreateProcess rules say command has to be writable!
+  std::vector<wchar_t> commandCopy(command.size() + 1);
+  wcscpy_s(&commandCopy[0], commandCopy.size(), command.c_str());
+  BOOL success = CreateProcess(NULL, &commandCopy[0], NULL, NULL, TRUE, flags,
+                               NULL, NULL, &startupInfo, &processInfo);
+  if (success) {
+    CloseHandle(processInfo.hThread);
+    hProcess_ = processInfo.hProcess;
+    return true;
+  } else {
+    LOG(ERROR) << "Error starting " << base::WStringToString(command) << ": "
+               << base::GetLastWindowsErrorString() << std::endl;
+  }
+
+  return false;
+}
+
+DWORD ChildProcess::GetExitCode() {
+  if (!hProcess_)
+    return 0;
+  // Don't allow getting the exit code unless the process has exited.
+  WaitForCompletion();
+  DWORD result;
+  (void)GetExitCodeProcess(hProcess_, &result);
+  return result;
+}
+
+void ChildProcess::WaitForCompletion() {
+  if (hProcess_) {
+    // Wait for the process to finish.
+    WaitForSingleObject(hProcess_, INFINITE);
+  }
+
+  // Close the stderr/stdout/stdin handles.
+  if (hStdError_ != INVALID_HANDLE_VALUE) {
+    CloseHandle(hStdError_);
+    hStdError_ = INVALID_HANDLE_VALUE;
+  }
+  if (hStdOutput_ != INVALID_HANDLE_VALUE) {
+    CloseHandle(hStdOutput_);
+    hStdOutput_ = INVALID_HANDLE_VALUE;
+  }
+  if (hStdInput_ != INVALID_HANDLE_VALUE) {
+    CloseHandle(hStdInput_);
+    hStdInput_ = INVALID_HANDLE_VALUE;
+  }
+}
+
+}  // namespace base

--- a/ETWInsights/base/child_process.h
+++ b/ETWInsights/base/child_process.h
@@ -1,0 +1,78 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <mutex>
+#include <string>
+
+#include "base/base.h"
+
+namespace base {
+
+// This class encapsulates running a child process and writing its output to a
+// file. Typical usage is:
+//   ChildProcess child();
+//   child.SetOutputPath(L"output.txt");
+//   child.Run(L"exename.exe -arg value");
+//   child.WaitForCompletion();
+// Run returns immediately. The destructor, GetExitCode(), and
+// WaitForCompletion() will all wait for the process to exit.
+
+class ChildProcess {
+ public:
+  ChildProcess();
+  // This waits for the child process to terminate.
+  ~ChildProcess();
+
+  // Sets the path to which output will be written.
+  void SetOutputPath(const std::wstring& output_path) {
+    output_path_ = output_path;
+  }
+
+  // Returns true if the process started. This function returns
+  // immediately without waiting for process completion.
+  _Pre_satisfies_(!(this->hProcess_)) bool Run(const std::wstring& command);
+
+  // This can be called even if the process doesn't start, but it will return
+  // zero. If the process is still running it will wait until the process
+  // returns and then get the exit code.
+  DWORD GetExitCode();
+
+  // Waits for the process to complete its execution. This is called by the
+  // destructor so calling it is strictly optional.
+  void WaitForCompletion();
+
+ private:
+  // Process, thread, and event handles have an uninitialized state of zero.
+  // Files have an uninitialized state of INVALID_HANDLE_VALUE. Yay Windows!
+  HANDLE hProcess_ = 0;
+
+  // Output handles for the child process.
+  HANDLE hStdOutput_ = INVALID_HANDLE_VALUE;
+  HANDLE hStdError_ = INVALID_HANDLE_VALUE;
+  HANDLE hStdInput_ = INVALID_HANDLE_VALUE;
+
+  // Output path.
+  std::wstring output_path_;
+
+  DISALLOW_COPY_AND_ASSIGN(ChildProcess);
+};
+
+}  // namespace base

--- a/ETWInsights/base/command_line.cc
+++ b/ETWInsights/base/command_line.cc
@@ -1,0 +1,75 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "base/command_line.h"
+
+#include "base/string_utils.h"
+
+namespace base {
+
+namespace {
+
+const wchar_t kSwitchNamePrefix[] = L"--";
+const size_t kSwitchNamePrefixLength =
+    (sizeof(kSwitchNamePrefix) / sizeof(wchar_t)) - 1;
+
+void ParseCommandLine(
+    int argc,
+    wchar_t* argv[],
+    std::unordered_map<std::wstring, std::wstring>* switches) {
+  std::wstring current_switch_name;
+  for (int i = 0; i < argc; ++i) {
+    std::wstring token(argv[i]);
+    // Check if this is a switch name.
+    if (base::WStringBeginsWith(token, kSwitchNamePrefix)) {
+      // Add the previous switch name to the switch map.
+      if (!current_switch_name.empty())
+        switches->insert({current_switch_name, std::wstring()});
+
+      // Keep track of the name of the current switch.
+      current_switch_name = token.substr(kSwitchNamePrefixLength);
+    } else if (!current_switch_name.empty()) {
+      // This a switch value. Add it to the switch map with its name.
+      switches->insert({current_switch_name, token});
+      current_switch_name.clear();
+    }
+  }
+
+  // If necessary, add the last switch name to the map.
+  if (!current_switch_name.empty())
+    switches->insert({current_switch_name, std::wstring()});
+}
+
+}  // namespace
+
+CommandLine::CommandLine(int argc, wchar_t* argv[]) {
+  ParseCommandLine(argc, argv, &switches_);
+}
+
+bool CommandLine::HasSwitch(const std::wstring& switch_name) const {
+  return switches_.find(switch_name) != switches_.end();
+}
+
+std::wstring CommandLine::GetSwitchValue(
+    const std::wstring& switch_name) const {
+  auto look = switches_.find(switch_name);
+  if (look == switches_.end())
+    return std::wstring();
+
+  return look->second;
+}
+
+}  // namespace base

--- a/ETWInsights/base/command_line.h
+++ b/ETWInsights/base/command_line.h
@@ -1,0 +1,49 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "base/base.h"
+
+namespace base {
+
+class CommandLine {
+ public:
+  // Constructs a command line from an argument list.
+  // @param argc Number of arguments.
+  // @param argv Arguments.
+  CommandLine(int argc, wchar_t* argv[]);
+
+  // @param switch_name Name of a switch.
+  // @returns true if the command line contains the given switch.
+  bool HasSwitch(const std::wstring& switch_name) const;
+
+  // @param switch_name Name of a switch.
+  // @returns the value associated with the switch, or an empty string if no
+  //    value was specified for the switch in the command line.
+  std::wstring GetSwitchValue(const std::wstring& switch_name) const;
+
+ private:
+  // Map Switch Name -> Switch Value.
+  std::unordered_map<std::wstring, std::wstring> switches_;
+
+  DISALLOW_COPY_AND_ASSIGN(CommandLine);
+};
+
+}  // namespace base

--- a/ETWInsights/base/error_string.cc
+++ b/ETWInsights/base/error_string.cc
@@ -1,0 +1,54 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "base/error_string.h"
+
+#include <sstream>
+#include <strsafe.h>
+
+#include "base/string_utils.h"
+
+namespace base {
+
+std::string GetWindowsErrorString(DWORD error) {
+  LPWSTR error_desc_buffer = NULL;
+  LPWSTR error_str_buffer = NULL;
+
+  ::FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                      FORMAT_MESSAGE_IGNORE_INSERTS,
+                  NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                  (LPTSTR)&error_desc_buffer, 0, NULL);
+
+  error_str_buffer = (LPWSTR)LocalAlloc(
+      LMEM_ZEROINIT,
+      (lstrlen((LPCTSTR)error_desc_buffer) + 40) * sizeof(TCHAR));
+  ::StringCchPrintf((LPTSTR)error_str_buffer,
+                    LocalSize(error_str_buffer) / sizeof(TCHAR),
+                    TEXT("%d - %s"), error, error_desc_buffer);
+
+  std::wstring error_str(error_str_buffer);
+
+  ::LocalFree(error_desc_buffer);
+  ::LocalFree(error_str_buffer);
+
+  return WStringToString(error_str);
+}
+
+std::string GetLastWindowsErrorString() {
+  return GetWindowsErrorString(::GetLastError());
+}
+
+}  // namespace base

--- a/ETWInsights/base/error_string.h
+++ b/ETWInsights/base/error_string.h
@@ -1,0 +1,33 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>  // NOLINT
+
+#include <string>
+
+namespace base {
+
+// @param error A Windows error code.
+// @returns The error message for the provided error code.
+std::string GetWindowsErrorString(DWORD error);
+
+// @returns The error message for the last Windows error.
+std::string GetLastWindowsErrorString();
+
+}  // namespace base

--- a/ETWInsights/base/file.cc
+++ b/ETWInsights/base/file.cc
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "base/file.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+namespace base {
+
+std::wstring DirName(const std::wstring& path) {
+  auto pos = path.rfind(L'\\');
+  if (pos == std::wstring::npos)
+    return std::wstring();
+  return path.substr(0, pos);
+}
+
+std::wstring BaseName(const std::wstring& path) {
+  size_t last_backslash = path.find_last_of(L"\\");
+  if (last_backslash == std::wstring::npos)
+    return path;
+  return path.substr(last_backslash + 1);
+}
+
+bool FilePathExists(const std::wstring& path) {
+  HANDLE handle = ::CreateFileW(path.c_str(),           // file to open
+                                GENERIC_READ,           // open for reading
+                                FILE_SHARE_READ,        // share for reading
+                                NULL,                   // default security
+                                OPEN_EXISTING,          // existing file only
+                                FILE_ATTRIBUTE_NORMAL,  // normal file
+                                NULL);                  // no attr. template
+  if (handle == INVALID_HANDLE_VALUE)
+    return false;
+  ::CloseHandle(handle);
+  return true;
+}
+
+}  // namespace base

--- a/ETWInsights/base/file.h
+++ b/ETWInsights/base/file.h
@@ -1,0 +1,36 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+
+namespace base {
+
+// @param path a file path.
+// @returns everything that comes before the last backslash in |path|. Empty if
+//     |path| doesn't contain a backslash.
+std::wstring DirName(const std::wstring& path);
+
+// @param path a file path.
+// @returns the last path component of the provided file path.
+std::wstring BaseName(const std::wstring& path);
+
+// @param path a file path.
+// @returns true if the file path exists, false otherwise.
+bool FilePathExists(const std::wstring& path);
+
+}  // namespace base

--- a/ETWInsights/base/history.h
+++ b/ETWInsights/base/history.h
@@ -1,0 +1,182 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#include "base/binary_search.h"
+#include "base/logging.h"
+#include "base/types.h"
+
+namespace base {
+
+// An History associates values to time ranges.
+template <typename T>
+class History {
+ public:
+  // An element of the history.
+  struct Element {
+    Element(const base::Timestamp& start_ts, const T& value)
+        : start_ts(start_ts), value(value) {}
+
+    // Time at which the element starts.
+    base::Timestamp start_ts;
+
+    // Value of the element.
+    T value;
+  };
+
+  typedef std::vector<Element> HistoryContainer;
+  typedef typename HistoryContainer::iterator HistoryIterator;
+  typedef typename HistoryContainer::const_iterator HistoryConstIterator;
+
+  History() {}
+
+  // Inserts a new value at the end of the history.
+  // @param ts start timestamp for the inserted value.
+  // @param value the value to insert.
+  // @returns true if the value is inserted successfully. Returns false if |ts|
+  //    is earlier than the timestamp of the last inserted value.
+  bool Insert(const base::Timestamp& start_ts, const T& value);
+
+  // Gets the value for the specified timestamp.
+  // @param ts timestamp for which to obtain the value.
+  // @param value value for the specified timestamp.
+  // @returns true if there is a value at the specified timestamp, false
+  //    otherwise.
+  bool GetValue(const base::Timestamp& ts, const T** value) const;
+
+  // Gets the value of the last inserted element.
+  // @param value the last value, output.
+  // @returns true if there is at least one element in the history, false
+  //    otherwise.
+  bool GetLastElementValue(T* value) const;
+
+  // Gets the timestamp of the last inserted element.
+  // @param ts the last timestamp, output.
+  // @returns true if there is at least one element in the history, false
+  //    otherwise.
+  bool GetLastElementTimestamp(base::Timestamp* ts) const;
+
+  // Returns an iterator to the first element of the history that ends after the
+  // specified timestamp.
+  // @param ts timestamp at which the iteration starts.
+  // @returns an iterator to the first value of the history that ends after the
+  //    specified timestamp.
+  HistoryIterator IteratorFromTimestamp(const base::Timestamp& ts);
+  HistoryConstIterator IteratorFromTimestamp(const base::Timestamp& ts) const;
+
+  // @returns an iterator to the end of the history.
+  HistoryIterator IteratorEnd();
+  HistoryConstIterator IteratorEnd() const;
+
+  // @returns the number of elements in the history.
+  size_t size() const { return history_.size(); }
+
+ private:
+  // Elements of the history, sorted by start timestamp.
+  HistoryContainer history_;
+};
+
+template <typename T>
+bool History<T>::Insert(const base::Timestamp& start_ts, const T& value) {
+  if (!history_.empty()) {
+    if (history_.back().start_ts >= start_ts)
+      return false;
+    if (history_.back().value == value)
+      return true;
+  }
+
+  history_.push_back(Element(start_ts, value));
+  return true;
+}
+
+template <typename T>
+bool History<T>::GetValue(const base::Timestamp& ts, const T** value) const {
+  DCHECK(value != nullptr);
+  auto it = base::FindSmallerOrEqual(
+      history_, ts, [](const base::Timestamp& ts, const Element& value) {
+        return ts < value.start_ts;
+      });
+
+  if (it == history_.end())
+    return false;
+
+  *value = &it->value;
+  return true;
+}
+
+template <typename T>
+bool History<T>::GetLastElementValue(T* value) const {
+  DCHECK(value != nullptr);
+  if (history_.empty())
+    return false;
+
+  *value = history_.back().value;
+  return true;
+}
+
+template <typename T>
+bool History<T>::GetLastElementTimestamp(base::Timestamp* ts) const {
+  DCHECK(ts != nullptr);
+  if (history_.empty())
+    return false;
+
+  *ts = history_.back().start_ts;
+  return true;
+}
+
+template <typename T>
+typename History<T>::HistoryIterator History<T>::IteratorFromTimestamp(
+    const base::Timestamp& ts) {
+  typename History<T>::HistoryIterator it = base::FindSmallerOrEqual(
+      history_, ts, [](const base::Timestamp& ts, const Element& value) {
+        return ts < value.start_ts;
+      });
+
+  if (it == history_.end())
+    return history_.begin();
+
+  return it;
+}
+
+template <typename T>
+typename History<T>::HistoryConstIterator History<T>::IteratorFromTimestamp(
+    const base::Timestamp& ts) const {
+  auto it = base::FindSmallerOrEqual(
+      history_, ts, [](const base::Timestamp& ts, const Element& value) {
+        return ts < value.start_ts;
+      });
+
+  if (it == history_.end())
+    return history_.begin();
+
+  return it;
+}
+
+template <typename T>
+typename History<T>::HistoryIterator History<T>::IteratorEnd() {
+  return history_.end();
+}
+
+template <typename T>
+typename History<T>::HistoryConstIterator History<T>::IteratorEnd() const {
+  return history_.end();
+}
+
+}  // namespace base

--- a/ETWInsights/base/logging.cc
+++ b/ETWInsights/base/logging.cc
@@ -1,0 +1,45 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <iostream>
+
+#include "base/logging.h"
+
+namespace base {
+
+LogMessage::~LogMessage() {
+  // TODO(etienneb): Implements a clever logging dispatch.
+  switch (severity_) {
+    case LOG_INFO:
+      std::cout << stream_.str();
+      break;
+    case LOG_WARNING:
+      std::cerr << "WARNING(" << file_ << ":" << line_ << "): " << stream_.str()
+                << std::endl;
+      break;
+    case LOG_ERROR:
+      std::cerr << "ERROR(" << file_ << ":" << line_ << "): " << stream_.str()
+                << std::endl;
+      break;
+    case LOG_FATAL:
+      std::cerr << "FATAL(" << file_ << ":" << line_ << "): " << stream_.str()
+                << std::endl;
+      exit(-1);  // TODO(etienneb): Do we really want this?
+      break;
+  }
+}
+
+}  // namespace base

--- a/ETWInsights/base/logging.h
+++ b/ETWInsights/base/logging.h
@@ -1,0 +1,64 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdlib>
+#include <sstream>
+
+#include "base/base.h"
+
+namespace base {
+
+enum LogSeverity { LOG_INFO, LOG_WARNING, LOG_ERROR, LOG_FATAL };
+
+class LogMessage {
+ public:
+  LogMessage(LogSeverity severity, const char* file, int line)
+      : severity_(severity), file_(file), line_(line) {}
+
+  ~LogMessage();
+
+  std::ostream& stream() { return stream_; }
+
+ private:
+  std::ostringstream stream_;
+  LogSeverity severity_;
+  const char* file_;
+  const int line_;
+
+  DISALLOW_COPY_AND_ASSIGN(LogMessage);
+};
+
+#define LOG(severity) \
+  base::LogMessage(base::LOG_##severity, __FILE__, __LINE__).stream()
+
+#ifndef NDEBUG
+#define DCHECK(cond) \
+  if (!(cond))       \
+  LOG(FATAL) << "'" << #cond << "' failed.\n"
+#else
+#define DCHECK(cond) (void)(cond);
+#endif
+
+#define DCHECK_EQ(a, b) DCHECK((a) == (b))
+#define DCHECK_NE(a, b) DCHECK((a) != (b))
+#define DCHECK_LT(a, b) DCHECK((a) < (b))
+#define DCHECK_LE(a, b) DCHECK((a) <= (b))
+#define DCHECK_GT(a, b) DCHECK((a) > (b))
+#define DCHECK_GE(a, b) DCHECK((a) >= (b))
+
+}  // namespace base

--- a/ETWInsights/base/numeric_conversions.cc
+++ b/ETWInsights/base/numeric_conversions.cc
@@ -1,0 +1,56 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "base/numeric_conversions.h"
+
+#include <stdlib.h>
+
+#include "base/logging.h"
+
+namespace base {
+
+bool StrToULong(const std::string& str, uint64_t* ulong) {
+  DCHECK(ulong);
+  try {
+    *ulong = std::stoull(str);
+    return true;
+  } catch (std::invalid_argument&) {
+    return false;
+  }
+}
+
+bool StrToULong(const std::wstring& str, uint64_t* ulong) {
+  DCHECK(ulong);
+  try {
+    *ulong = std::stoull(str);
+    return true;
+  } catch (std::invalid_argument&) {
+    return false;
+  }
+}
+
+bool StrToULongHex(const std::string& str, uint64_t* ulong) {
+  DCHECK(ulong);
+  try {
+    size_t pos = 0;
+    *ulong = std::stoull(str, &pos, 16);
+    return true;
+  } catch (std::invalid_argument&) {
+    return false;
+  }
+}
+
+}  // namespace base

--- a/ETWInsights/base/numeric_conversions.h
+++ b/ETWInsights/base/numeric_conversions.h
@@ -1,0 +1,31 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+namespace base {
+
+// @param str a string to convert to unsigned long.
+// @param ulong the result of the conversion.
+// @returns true if the conversion was successful, false otherwise.
+bool StrToULong(const std::string& str, uint64_t* ulong);
+bool StrToULong(const std::wstring& str, uint64_t* ulong);
+bool StrToULongHex(const std::string& str, uint64_t* ulong);
+
+}  // namespace base

--- a/ETWInsights/base/string_utils.cc
+++ b/ETWInsights/base/string_utils.cc
@@ -1,0 +1,212 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "base/string_utils.h"
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <sstream>
+
+namespace base {
+
+namespace {
+
+template <typename T>
+bool StringBeginsWithInternal(const T& str, const T& starting) {
+  if (str.compare(0, starting.length(), starting) == 0)
+    return true;
+  return false;
+}
+
+template <typename T>
+bool StringEndsWithInternal(const T& str, const T& ending) {
+  if (ending.length() > str.length())
+    return false;
+
+  if (str.compare(str.length() - ending.length(), ending.length(), ending) ==
+      0) {
+    return true;
+  }
+
+  return false;
+}
+
+template <typename T>
+bool SubstrAtPosInternal(const T& str, const T& substr, size_t pos) {
+  if (pos + substr.size() > str.size())
+    return false;
+  for (size_t i = 0; i < substr.size(); ++i) {
+    if (str[i + pos] != substr[i])
+      return false;
+  }
+  return true;
+}
+
+template <typename T>
+std::vector<T> SplitStringInternal(const T& str, const T& separator) {
+  std::vector<T> res;
+  size_t start_index = 0;
+  size_t end_index = 0;
+
+  while (start_index < str.size()) {
+    while (end_index < str.size() &&
+           !SubstrAtPosInternal(str, separator, end_index))
+      ++end_index;
+    res.push_back(str.substr(start_index, end_index - start_index));
+    start_index = end_index + separator.size();
+    end_index = start_index;
+  }
+
+  return res;
+}
+
+template <typename T>
+T TrimInternal(const T& str) {
+  // Find position of first and last non-space character.
+  auto first = std::find_if(str.begin(), str.end(),
+                            std::not1(std::ptr_fun(std::isspace)));
+  auto last = std::find_if(str.rbegin(), str.rend(),
+                           std::not1(std::ptr_fun(std::isspace)));
+
+  auto first_index = std::distance(str.begin(), first);
+  auto length = std::distance(last, str.rend()) - first_index;
+
+  return str.substr(first_index, length);
+}
+
+template <typename T>
+void ReplaceAllInternal(const T& search,
+                        const T& replace,
+                        T* str) {
+  size_t search_pos = 0;
+  size_t token_pos;
+
+  while ((token_pos = str->find(search, search_pos)) != T::npos) {
+    str->replace(token_pos, search.length(), replace);
+    search_pos = token_pos + replace.size();
+  }
+}
+
+}  // namespace
+
+std::wstring StringToWString(const std::string& string) {
+  return std::wstring(string.begin(), string.end());
+}
+
+std::string WStringToString(const std::wstring& string) {
+  return std::string(string.begin(), string.end());
+}
+
+bool SubstrAtPos(const std::string& str,
+                 const std::string& substr,
+                 size_t pos) {
+  return SubstrAtPosInternal(str, substr, pos);
+}
+
+bool WSubstrAtPos(const std::wstring& str,
+                  const std::wstring& substr,
+                  size_t pos) {
+  return SubstrAtPosInternal(str, substr, pos);
+}
+
+bool StringBeginsWith(const std::string& str, const std::string& starting) {
+  return StringBeginsWithInternal(str, starting);
+}
+
+bool WStringBeginsWith(const std::wstring& str, const std::wstring& starting) {
+  return StringBeginsWithInternal(str, starting);
+}
+
+bool StringEndsWith(const std::string& str, const std::string& ending) {
+  return StringEndsWithInternal(str, ending);
+}
+
+bool WStringEndsWith(const std::wstring& str, const std::wstring& ending) {
+  return StringEndsWithInternal(str, ending);
+}
+
+std::string StringEscapeSpecialCharacter(const std::string& str) {
+  std::stringstream ss;
+  for (std::string::const_iterator i = str.begin(); i != str.end(); ++i) {
+    unsigned char c = *i;
+    if (' ' <= c && c <= '~' && c != '\\' && c != '"') {
+      ss << c;
+      continue;
+    }
+
+    ss << '\\';
+
+    switch (c) {
+      case '"':
+        ss << '"';
+        break;
+      case '\\':
+        ss << '\\';
+        break;
+      case '\t':
+        ss << 't';
+        break;
+      case '\r':
+        ss << 'r';
+        break;
+      case '\n':
+        ss << 'n';
+        break;
+      default: {
+        static char const* const hexdig = "0123456789ABCDEF";
+        ss << 'x';
+        ss << hexdig[c >> 4];
+        ss << hexdig[c & 0xF];
+        break;
+      }
+    }
+  }
+
+  return ss.str();
+}
+
+std::vector<std::string> SplitString(const std::string& str,
+                                     const std::string& separator) {
+  return SplitStringInternal(str, separator);
+}
+
+std::vector<std::wstring> SplitWString(const std::wstring& str,
+                                       const std::wstring& separator) {
+  return SplitStringInternal(str, separator);
+}
+
+std::string Trim(const std::string& str) {
+  return TrimInternal(str);
+}
+
+std::wstring TrimW(const std::wstring& str) {
+  return TrimInternal(str);
+}
+
+void ReplaceAll(const std::string& search,
+                const std::string& replace,
+                std::string* str) {
+  ReplaceAllInternal(search, replace, str);
+}
+
+void ReplaceAllW(const std::wstring& search,
+                 const std::wstring& replace,
+                 std::wstring* str) {
+  ReplaceAllInternal(search, replace, str);
+}
+
+}  // namespace base

--- a/ETWInsights/base/string_utils.h
+++ b/ETWInsights/base/string_utils.h
@@ -1,0 +1,65 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace base {
+
+// Convert between ASCII and Unicode strings.
+std::wstring StringToWString(const std::string& string);
+std::string WStringToString(const std::wstring& string);
+
+// Returns true if |str| contains |substr| at position |pos|.
+bool SubstrAtPos(const std::string& str, const std::string& substr, size_t pos);
+bool WSubstrAtPos(const std::wstring& str,
+                  const std::wstring& substr,
+                  size_t pos);
+
+// Returns true if |str| begins with |starting|, or false otherwise.
+bool StringBeginsWith(const std::string& str, const std::string& starting);
+bool WStringBeginsWith(const std::wstring& str, const std::wstring& starting);
+
+// Returns true if |str| ends with |ending|, or false otherwise.
+bool StringEndsWith(const std::string& str, const std::string& ending);
+bool WStringEndsWith(const std::wstring& str, const std::wstring& ending);
+
+// Escape the C special characters with a backslash.
+// @param str the string to be escaped.
+// @returns a string escaped copy of |str|.
+std::string StringEscapeSpecialCharacter(const std::string& str);
+
+// Splits |str| at each occurrence of |separator|.
+std::vector<std::string> SplitString(const std::string& str,
+                                     const std::string& separator);
+std::vector<std::wstring> SplitWString(const std::wstring& str,
+                                       const std::wstring& separator);
+
+// Removes spaces at the beginning and end of |str|.
+std::string Trim(const std::string& str);
+std::wstring TrimW(const std::wstring& str);
+
+// Replaces all occurrences of |search| in |str| by |replace|.
+void ReplaceAll(const std::string& search,
+                const std::string& replace,
+                std::string* str);
+void ReplaceAllW(const std::wstring& search,
+                 const std::wstring& replace,
+                 std::wstring* str);
+
+}  // namespace base

--- a/ETWInsights/base/types.h
+++ b/ETWInsights/base/types.h
@@ -1,0 +1,33 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+namespace base {
+
+typedef uint64_t Timestamp;
+typedef uint64_t Pid;
+typedef uint64_t Tid;
+
+const Timestamp kInvalidTimestamp = static_cast<Timestamp>(-1);
+const Pid kInvalidPid = static_cast<Pid>(-1);
+const Tid kInvalidTid = static_cast<Tid>(-1);
+
+}  // namespace base

--- a/ETWInsights/etw_reader/etw_reader.cc
+++ b/ETWInsights/etw_reader/etw_reader.cc
@@ -1,0 +1,238 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "etw_reader/etw_reader.h"
+
+#include "base/child_process.h"
+#include "base/file.h"
+#include "base/logging.h"
+#include "base/numeric_conversions.h"
+#include "base/string_utils.h"
+
+namespace etw_insights {
+
+namespace {
+// CSV column separator.
+const char kSeparator[] = ",";
+
+// Extension for a CSV file.
+const wchar_t kCSVFileExtension[] = L".csv";
+
+// Invalid line index.
+const size_t kInvalidLineIndex = static_cast<size_t>(-1);
+
+std::vector<std::string> ExtractTokens(const std::string& str) {
+  std::vector<std::string> tokens(base::SplitString(str, kSeparator));
+  for (auto& token : tokens)
+    token = base::Trim(token);
+  return tokens;
+}
+
+std::wstring ConvertEtlToCsv(const std::wstring& etl_path) {
+  // Generate the name of the CSV file.
+  std::wstring csv_path = etl_path + kCSVFileExtension;
+
+  // Check if the CSV file already exists.
+  if (base::FilePathExists(csv_path))
+    return csv_path;
+
+  // Tell the user what we are doing.
+  LOG(INFO) << "Converting trace file to CSV format." << std::endl;
+
+  // Generate the CSV file.
+  base::ChildProcess xperf_process;
+  xperf_process.SetOutputPath(csv_path);
+  std::wstringstream command;
+  command << L"xperf -i \"" << etl_path << "\" -symbols";
+  xperf_process.Run(command.str());
+
+  return csv_path;
+}
+}  // namespace
+
+const char* ETWReader::kEmptyEventType = "Empty";
+
+ETWReader::Line::Line() {}
+
+bool ETWReader::Line::GetFieldAsString(const std::string& name,
+                                       std::string* value) const {
+  auto look = values_.find(name);
+  if (look == values_.end())
+    return false;
+  *value = look->second;
+  return true;
+}
+
+bool ETWReader::Line::GetFieldAsULong(const std::string& name,
+                                      uint64_t* value) const {
+  std::string value_str;
+  if (!GetFieldAsString(name, &value_str))
+    return false;
+  return base::StrToULong(value_str, value);
+}
+
+bool ETWReader::Line::GetFieldAsULongHex(const std::string& name,
+                                         uint64_t* value) const {
+  std::string value_str;
+  if (!GetFieldAsString(name, &value_str))
+    return false;
+  return base::StrToULongHex(value_str, value);
+}
+
+ETWReader::Iterator::Iterator() : current_line_index_(kInvalidLineIndex) {}
+
+bool ETWReader::Iterator::operator==(const ETWReader::Iterator& other) const {
+  return current_line_index_ == other.current_line_index_;
+}
+
+bool ETWReader::Iterator::operator!=(const ETWReader::Iterator& other) const {
+  return current_line_index_ != other.current_line_index_;
+}
+
+ETWReader::Iterator& ETWReader::Iterator::operator++() {
+  // Reset the current line values.
+  current_line_.values_.clear();
+
+  // Read the current line.
+  std::string line;
+  if (!std::getline(file_, line)) {
+    current_line_index_ = kInvalidLineIndex;
+    return *this;
+  }
+  ++current_line_index_;
+  auto tokens = ExtractTokens(line);
+
+  // Check if the current line is empty.
+  if (tokens.empty()) {
+    current_line_.type_ = kEmptyEventType;
+    return *this;
+  }
+
+  // Set the current line type.
+  current_line_.type_ = tokens.front();
+
+  // Get the column names for this line type.
+  auto look_column_names = header_.find(current_line_.type());
+  if (look_column_names == header_.end()) {
+    current_line_.values_.clear();
+    return *this;
+  }
+  const auto& column_names = look_column_names->second;
+
+  // Check that we got the expected number of tokens.
+  if ((tokens.size() - 1) < column_names.size()) {
+    LOG(ERROR) << "Unexpected number of tokens for line of type "
+               << current_line_.type() << ".";
+    return *this;
+  }
+
+  // Create a map of Column Name -> Column Value for the current line.
+  for (size_t column_index = 0; column_index < column_names.size();
+       ++column_index) {
+    size_t token_index = column_index + 1;
+    std::string value = tokens[token_index];
+
+    // If this is the last column, use all the remaining tokens as the value.
+    // TODO(fdoray): Find a cleaner solution.
+    if (column_index == column_names.size() - 1) {
+      ++token_index;
+      while (token_index < tokens.size()) {
+        value += ",";
+        value += tokens[token_index];
+        ++token_index;
+      }
+    }
+
+    current_line_.values_[column_names[column_index]] = value;
+  }
+
+  return *this;
+}
+
+ETWReader::Iterator::Iterator(const std::wstring& file_path)
+    : current_line_index_(static_cast<size_t>(0)) {
+  // Open the CSV file.
+  file_.open(file_path);
+
+  // Parse the header.
+  ParseHeader();
+
+  // Skip the line with the trace metadata.
+  std::string dummy;
+  std::getline(file_, dummy);
+  ++current_line_index_;
+
+  // Read the first event line.
+  ++(*this);
+}
+
+void ETWReader::Iterator::ParseHeader() {
+  bool read_first_line = false;
+  std::string line;
+  while (std::getline(file_, line)) {
+    ++current_line_index_;
+
+    // Ignore the first line.
+    if (!read_first_line) {
+      read_first_line = true;
+      continue;
+    }
+
+    // Stop when the EndHeader line is encountered.
+    if (line == "EndHeader")
+      break;
+
+    // Extract tokens names from the line.
+    auto tokens = ExtractTokens(line);
+
+    // The first token is the line type.
+    auto type = tokens.front();
+
+    // The other tokens are column names.
+    auto column_names =
+        std::vector<std::string>(tokens.begin() + 1, tokens.end());
+
+    // Save the Line type -> Column names pair.
+    header_[type] = column_names;
+  }
+}
+
+ETWReader::ETWReader() {}
+
+bool ETWReader::Open(const std::wstring& trace_path) {
+  // Check that the ETL file exists.
+  if (!base::FilePathExists(trace_path)) {
+    LOG(ERROR) << "Trace file " << base::WStringToString(trace_path)
+               << " doesn't exist.";
+    return false;
+  }
+
+  // Convert the ETL file to CSV.
+  csv_file_path_ = ConvertEtlToCsv(trace_path);
+
+  return true;
+}
+
+ETWReader::Iterator ETWReader::begin() const {
+  DCHECK(!csv_file_path_.empty());
+  return Iterator(csv_file_path_);
+}
+
+ETWReader::Iterator ETWReader::end() const {
+  return Iterator();
+}
+
+}  // namespace etw_insights

--- a/ETWInsights/etw_reader/etw_reader.h
+++ b/ETWInsights/etw_reader/etw_reader.h
@@ -1,0 +1,106 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <fstream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "base/base.h"
+
+namespace etw_insights {
+
+// Reads an ETW trace.
+class ETWReader {
+ public:
+  class Iterator;
+
+  // A line of an ETW trace dumped into a CSV file.
+  class Line {
+   public:
+    Line();
+
+    const std::string& type() const { return type_; }
+
+    bool GetFieldAsString(const std::string& name, std::string* value) const;
+    bool GetFieldAsULong(const std::string& name, uint64_t* value) const;
+    bool GetFieldAsULongHex(const std::string& name, uint64_t* value) const;
+
+   private:
+    friend class etw_insights::ETWReader::Iterator;
+
+    std::string type_;
+    std::unordered_map<std::string, std::string> values_;
+  };
+
+  // Iterates through the events of an ETW trace.
+  class Iterator {
+   public:
+    Iterator();
+
+    const Line& operator*() const { return current_line_; }
+    const Line* operator->() const { return &current_line_; }
+    bool operator==(const Iterator& other) const;
+    bool operator!=(const Iterator& other) const;
+    Iterator& operator++();
+
+   private:
+    friend class etw_insights::ETWReader;
+
+    Iterator(const std::wstring& file_path);
+
+    void ParseHeader();
+
+    // CSV file stream.
+    std::ifstream file_;
+
+    // CSV header: Line type -> Column names.
+    std::unordered_map<std::string, std::vector<std::string>> header_;
+
+    // Current line index.
+    size_t current_line_index_;
+
+    // Current line.
+    Line current_line_;
+  };
+
+  ETWReader();
+
+  // Opens an ETW trace.
+  // @param trace_path Path to a .etl file.
+  // @returns true if the trace was opened successfully, false otherwise.
+  bool Open(const std::wstring& trace_path);
+
+  // Returns an iterator to the first event of an ETW trace.
+  Iterator begin() const;
+
+  // Returns an iterator to the end of an ETW trace.
+  Iterator end() const;
+
+  // Empty event type.
+  static const char* kEmptyEventType;
+
+ private:
+  // Path to the CSV dump of an ETW trace.
+  std::wstring csv_file_path_;
+
+  DISALLOW_COPY_AND_ASSIGN(ETWReader);
+};
+
+}  // namespace etw_insights

--- a/ETWInsights/etw_reader/etw_reader.vcxproj
+++ b/ETWInsights/etw_reader/etw_reader.vcxproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="etw_reader.cc" />
+    <ClCompile Include="generate_history_from_trace.cc" />
+    <ClCompile Include="system_history.cc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="etw_reader.h" />
+    <ClInclude Include="generate_history_from_trace.h" />
+    <ClInclude Include="stack.h" />
+    <ClInclude Include="system_history.h" />
+    <ClInclude Include="thread_history.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\base\base.vcxproj">
+      <Project>{637388ca-e6e9-4d38-8dc9-cc2fe937de24}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E1FCFE0C-B8CB-4516-9F46-54C1F73A9601}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>etw_reader</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/ETWInsights/etw_reader/etw_reader.vcxproj.filters
+++ b/ETWInsights/etw_reader/etw_reader.vcxproj.filters
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="etw_reader.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="generate_history_from_trace.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="system_history.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="etw_reader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="generate_history_from_trace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stack.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="system_history.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="thread_history.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/ETWInsights/etw_reader/generate_history_from_trace.cc
+++ b/ETWInsights/etw_reader/generate_history_from_trace.cc
@@ -1,0 +1,429 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "etw_reader/generate_history_from_trace.h"
+
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include "base/numeric_conversions.h"
+#include "base/string_utils.h"
+#include "base/types.h"
+#include "etw_reader/etw_reader.h"
+
+namespace etw_insights {
+
+namespace {
+
+// [Off-CPU] stack frame.
+const char kOffCpuStackFrame[] = "[Off-CPU]";
+
+// Generic event fields.
+const char kTimestampField[] = "TimeStamp";
+const char kThreadIDField[] = "ThreadID";
+const char kProcessNameField[] = "Process Name ( PID)";
+
+// Stack event.
+const char kStackType[] = "Stack";
+const char kStackSymbolField[] = "Image!Function";
+
+// Sampled profile event.
+const char kSampledProfileType[] = "SampledProfile";
+
+// CSwitch event.
+const char kCSwitchType[] = "CSwitch";
+const char kCSwitchNewTidField[] = "New TID";
+const char kCSwitchOldTidField[] = "Old TID";
+const char kCSwitchTimeSinceLastField[] = "TmSinceLast";
+
+// Process start event.
+const char kProcessStartType[] = "P-Start";
+const char kProcessDCStartType[] = "P-DCStart";
+
+// Thread start event.
+const char kThreadStartType[] = "T-Start";
+const char kThreadDCStartType[] = "T-DCStart";
+
+// Thread end event.
+const char kThreadEndType[] = "T-End";
+const char kThreadDCEndType[] = "T-DCEnd";
+
+// FileIo events.
+const char kFileIoCreateType[] = "FileIoCreate";
+const char kFileIoCleanupType[] = "FileIoCleanup";
+const char kFileIoCloseType[] = "FileIoClose";
+const char kFileIoFlushType[] = "FileIoFlush";
+const char kFileIoReadType[] = "FileIoRead";
+const char kFileIoWriteType[] = "FileIoWrite";
+const char kFileIoSetInfoType[] = "FileIoSetInfo";
+const char kFileIoQueryInfoType[] = "FileIoQueryInfo";
+const char kFileIoFSCTLType[] = "FileIoFSCTL";
+const char kFileIoDeleteType[] = "FileIoDelete";
+const char kFileIoRenameType[] = "FileIoRename";
+const char kFileIoDirEnumType[] = "FileIoDirEnum";
+const char kFileIoDirNotifyType[] = "FileIoDirNotify";
+const char kFileIoOpEnd[] = "FileIoOpEnd";
+const char kFileIoFileNameField[] = "FileName";
+const char kFileIoTypeField[] = "Type";
+const char kFileIoLoggingThreadIdField[] = "LoggingThreadID";
+
+// Chrome events.
+const char kChromeType[] = "Chrome//win:Info";
+const char kChromeNameField[] = "Name";
+const char kChromePhaseField[] = "Phase";
+const char kChromeNonEmptyPaint[] =
+    "\"Startup.FirstWebContents.NonEmptyPaint\"";
+const char kChromePhaseAsyncBegin[] = "\"Async End\"";
+
+// Unknown stack frame.
+const char kUnknownStackFrame[] = "[Unknown]";
+
+// State of a thread.
+struct ThreadState {
+  ThreadState() {}
+
+  // Active file operation.
+  std::string file_operation;
+
+  // Last events encountered on the thread (timestamp -> type).
+  std::map<base::Timestamp, std::string> last_events;
+
+  // Timestamp of the last switch out that occurred before each switch in.
+  // (Switch in ts -> Switch out ts).
+  std::map<base::Timestamp, base::Timestamp> last_switch_out_before_switch_in_;
+};
+
+typedef std::unordered_map<base::Tid, ThreadState> ThreadStates;
+
+Stack ConcatenateStacks(std::initializer_list<Stack> stacks) {
+  Stack stack_res;
+  for (const auto& stack : stacks)
+    stack_res.insert(stack_res.end(), stack.begin(), stack.end());
+  return stack_res;
+}
+
+void SplitProcessNameField(const std::string& value,
+                           std::string* process_name,
+                           base::Pid* pid) {
+  auto tokens = base::SplitString(value, " ");
+  *process_name = tokens[0];
+
+  size_t start_pos = 0;
+  if (tokens.back()[0] == '(')
+    start_pos = 1;
+
+  if (!base::StrToULong(
+          tokens.back().substr(start_pos, tokens.back().size() - 1 - start_pos),
+          pid)) {
+    LOG(ERROR) << "Unable to extract process id from process name field ("
+               << value << ").";
+  }
+}
+
+void HandleStackEvent(base::Timestamp ts,
+                      ETWReader::Iterator& it,
+                      ThreadStates* thread_states,
+                      SystemHistory* system_history) {
+  // Get the event tid.
+  base::Tid tid = 0;
+  if (!it->GetFieldAsULong(kThreadIDField, &tid))
+    LOG(ERROR) << "Unable to read column ThreadID of Stack event.";
+
+  // Get the event stack.
+  Stack stack;
+  while (it->type() == kStackType) {
+    std::string symbol;
+    if (!it->GetFieldAsString(kStackSymbolField, &symbol))
+      continue;
+    stack.push_back(symbol);
+    ++it;
+  }
+  DCHECK_EQ(ETWReader::kEmptyEventType, it->type());
+
+  // Get the associated event type.
+  const ThreadState& thread_state = (*thread_states)[tid];
+  auto look_associated_event_type = thread_state.last_events.find(ts);
+  if (look_associated_event_type == thread_state.last_events.end())
+    return;
+  auto associated_event_type = look_associated_event_type->second;
+
+  // Get the stack history for the thread.
+  auto& stack_history = system_history->GetThread(tid).Stacks();
+  base::Timestamp last_stack_ts = 0;
+  stack_history.GetLastElementTimestamp(&last_stack_ts);
+
+  if (associated_event_type == kSampledProfileType) {
+    // Handle a call stack associated with a SampledProfile event.
+    if (last_stack_ts == ts) {
+      auto stack_history_it = stack_history.IteratorFromTimestamp(ts);
+      stack_history_it->value =
+          ConcatenateStacks({stack_history_it->value, stack});
+    } else {
+      stack_history.Insert(ts, stack);
+    }
+  } else if (associated_event_type == kCSwitchType) {
+    // Handle a call stack associated with a CSwitch event.
+
+    // Get the switch in and switch out times.
+    base::Timestamp switch_in_time = ts;
+    auto look_switch_out_time =
+        thread_state.last_switch_out_before_switch_in_.find(switch_in_time);
+    if (look_switch_out_time ==
+        thread_state.last_switch_out_before_switch_in_.end()) {
+      LOG(ERROR) << "No switch out time for CSwitch stack.";
+      return;
+    }
+    base::Timestamp switch_out_time = look_switch_out_time->second;
+
+    // Update the call stack history.
+    if (switch_in_time != switch_out_time) {
+      if (last_stack_ts == ts) {
+        // Concatenate this CSwitch stack to another CSwitch stack that we got
+        // previously.
+        auto stack_history_it =
+            stack_history.IteratorFromTimestamp(switch_out_time);
+        stack_history_it->value =
+            ConcatenateStacks({stack_history_it->value, stack});
+      } else {
+        // Save the previous stack.
+        Stack previous_stack;
+        stack_history.GetLastElementValue(&previous_stack);
+
+        // Add the blocked stack.
+        Stack off_cpu_synthetic_stack;
+        if (!thread_state.file_operation.empty())
+          off_cpu_synthetic_stack.push_back(thread_state.file_operation);
+        off_cpu_synthetic_stack.push_back(kOffCpuStackFrame);
+
+        stack_history.Insert(
+            switch_out_time,
+            ConcatenateStacks({off_cpu_synthetic_stack, stack}));
+
+        // Add the stack that follow the blocked stack.
+        if (previous_stack.empty()) {
+          previous_stack.push_back(kUnknownStackFrame);
+        }
+
+        stack_history.Insert(switch_in_time, previous_stack);
+      }
+    }
+  }
+}
+
+void HandleCSwitchEvent(base::Timestamp ts,
+                        const ETWReader::Line& event,
+                        ThreadStates* thread_states) {
+  base::Tid new_tid = 0;
+  base::Tid old_tid = 0;
+  base::Timestamp time_since_last = 0;
+  if (!event.GetFieldAsULong(kCSwitchNewTidField, &new_tid) ||
+      !event.GetFieldAsULong(kCSwitchOldTidField, &old_tid) ||
+      !event.GetFieldAsULong(kCSwitchTimeSinceLastField, &time_since_last)) {
+    LOG(ERROR) << "Missing some fields in CSwitch event at ts=" << ts << ".";
+    return;
+  }
+
+  ThreadState& new_thread_state = (*thread_states)[new_tid];
+  new_thread_state.last_switch_out_before_switch_in_[ts] = ts - time_since_last;
+}
+
+void HandleProcessStartEvent(base::Timestamp ts,
+                             const ETWReader::Line& event,
+                             SystemHistory* system_history) {
+  std::string process_name_field;
+  if (!event.GetFieldAsString(kProcessNameField, &process_name_field)) {
+    LOG(ERROR) << "Missing some fields in Process Start event at ts=" << ts
+               << ".";
+    return;
+  }
+
+  std::string process_name;
+  base::Pid process_id = base::kInvalidPid;
+  SplitProcessNameField(process_name_field, &process_name, &process_id);
+
+  system_history->SetProcessName(process_id, process_name);
+}
+
+void HandleThreadStartEvent(base::Timestamp ts,
+                            const ETWReader::Line& event,
+                            SystemHistory* system_history) {
+  base::Tid thread_id = 0;
+  std::string process_name_field;
+  if (!event.GetFieldAsULong(kThreadIDField, &thread_id) ||
+      !event.GetFieldAsString(kProcessNameField, &process_name_field)) {
+    LOG(ERROR) << "Missing some fields in Thread Start event at ts=" << ts
+               << ".";
+    return;
+  }
+
+  std::string process_name;
+  base::Pid process_id = base::kInvalidPid;
+  SplitProcessNameField(process_name_field, &process_name, &process_id);
+
+  auto& thread_history = system_history->GetThread(thread_id);
+  thread_history.set_start_ts(ts);
+  thread_history.set_parent_process_id(process_id);
+}
+
+void HandleThreadEndEvent(base::Timestamp ts,
+                          const ETWReader::Line& event,
+                          SystemHistory* system_history) {
+  base::Tid thread_id = 0;
+  if (!event.GetFieldAsULong(kThreadIDField, &thread_id)) {
+    LOG(ERROR) << "Missing some fields in Thread End event at ts=" << ts << ".";
+    return;
+  }
+
+  auto& thread_history = system_history->GetThread(thread_id);
+  thread_history.set_end_ts(ts);
+}
+
+void HandleFileIoEvent(base::Timestamp ts,
+                       const ETWReader::Line& event,
+                       ThreadStates* thread_states) {
+  base::Tid thread_id = 0;
+  std::string file_name;
+  if (!event.GetFieldAsULong(kFileIoLoggingThreadIdField, &thread_id) ||
+      !event.GetFieldAsString(kFileIoFileNameField, &file_name)) {
+    LOG(ERROR) << "Missing some fields in FileIo event at ts=" << ts << ".";
+    return;
+  }
+
+  std::string event_str(std::string("[") + event.type() + ": " + file_name +
+                        "]");
+  auto& thread_state = (*thread_states)[thread_id];
+  thread_state.file_operation = event_str;
+}
+
+void HandleFileIoOpEndEvent(base::Timestamp ts,
+                            const ETWReader::Line& event,
+                            ThreadStates* thread_states) {
+  base::Tid thread_id = 0;
+  std::string file_name;
+  if (!event.GetFieldAsULong(kFileIoLoggingThreadIdField, &thread_id) ||
+      !event.GetFieldAsString(kFileIoFileNameField, &file_name)) {
+    LOG(ERROR) << "Missing some fields in FileIoOpEnd event at ts=" << ts
+               << ".";
+    return;
+  }
+
+  auto& thread_state = (*thread_states)[thread_id];
+  thread_state.file_operation.clear();
+}
+
+void HandleChromeEvent(base::Timestamp ts,
+                       const ETWReader::Line& event,
+                       SystemHistory* system_history,
+                       bool* should_stop) {
+  std::string name;
+  std::string phase;
+  if (!event.GetFieldAsString(kChromeNameField, &name) ||
+      !event.GetFieldAsString(kChromePhaseField, &phase)) {
+    LOG(ERROR) << "Missing some fields in Chrome event at ts=" << ts << ".";
+    return;
+  }
+
+  if (name == kChromeNonEmptyPaint && phase == kChromePhaseAsyncBegin) {
+    system_history->set_first_non_empty_paint_ts(ts);
+    *should_stop = true;
+  }
+}
+
+}  // namespace
+
+bool GenerateHistoryFromTrace(const std::wstring& trace_path,
+                              SystemHistory* system_history) {
+  // Keeps track of the current state of each thread.
+  std::unordered_map<base::Tid, ThreadState> thread_states;
+
+  // Open the CSV trace.
+  ETWReader etw_reader;
+  if (!etw_reader.Open(trace_path))
+    return false;
+
+  // Tell the user what we are doing.
+  LOG(INFO) << "Reading trace events." << std::endl;
+
+  // Traverse all the events of the CSV trace.
+  for (auto it = etw_reader.begin(); it != etw_reader.end(); ++it) {
+    // Should we stop parsing the trace?
+    bool should_stop = false;
+
+    // Get the event timestamp.
+    base::Timestamp ts = 0;
+    it->GetFieldAsULong(kTimestampField, &ts);
+
+    // Handle each event type.
+    if (it->type() == kStackType)
+      HandleStackEvent(ts, it, &thread_states, system_history);
+    else if (it->type() == kCSwitchType)
+      HandleCSwitchEvent(ts, *it, &thread_states);
+    else if (it->type() == kProcessStartType ||
+             it->type() == kProcessDCStartType)
+      HandleProcessStartEvent(ts, *it, system_history);
+    else if (it->type() == kThreadStartType || it->type() == kThreadDCStartType)
+      HandleThreadStartEvent(ts, *it, system_history);
+    else if (it->type() == kThreadEndType || it->type() == kThreadDCEndType)
+      HandleThreadEndEvent(ts, *it, system_history);
+    else if (it->type() == kFileIoCreateType ||
+             it->type() == kFileIoCleanupType ||
+             it->type() == kFileIoCloseType ||
+             it->type() == kFileIoFlushType ||
+             it->type() == kFileIoReadType ||
+             it->type() == kFileIoWriteType ||
+             it->type() == kFileIoSetInfoType ||
+             it->type() == kFileIoQueryInfoType ||
+             it->type() == kFileIoFSCTLType ||
+             it->type() == kFileIoDeleteType ||
+             it->type() == kFileIoRenameType ||
+             it->type() == kFileIoDirEnumType ||
+             it->type() == kFileIoDirNotifyType)
+      HandleFileIoEvent(ts, *it, &thread_states);
+    else if (it->type() == kFileIoOpEnd)
+      HandleFileIoOpEndEvent(ts, *it, &thread_states);
+    else if (it->type() == kChromeType)
+      HandleChromeEvent(ts, *it, system_history, &should_stop);
+
+    // Remember the last event types encountered on each thread.
+    base::Tid tid = 0;
+    if (it->GetFieldAsULong(kThreadIDField, &tid) ||
+        it->GetFieldAsULong(kCSwitchNewTidField, &tid)) {
+      ThreadState& thread_state = thread_states[tid];
+      thread_state.last_events[ts] = it->type();
+    }
+
+    // Keep track of the timestamp of the first and last events of the trace.
+    if (ts != 0) {
+      if (system_history->first_event_ts() == 0 ||
+          system_history->first_event_ts() > ts) {
+        system_history->set_first_event_ts(ts);
+      }
+      if (system_history->last_event_ts() == base::kInvalidTimestamp ||
+          system_history->last_event_ts() < ts) {
+        system_history->set_last_event_ts(ts);
+      }
+    }
+
+    // Stop parsing the trace.
+    if (should_stop)
+      break;
+  }
+
+  return true;
+}
+
+}  // namespace etw_insights

--- a/ETWInsights/etw_reader/generate_history_from_trace.h
+++ b/ETWInsights/etw_reader/generate_history_from_trace.h
@@ -1,0 +1,32 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+
+#include "etw_reader/system_history.h"
+
+namespace etw_insights {
+
+// Traverses the event of an ETW trace to fill a system history.
+// @param trace_path Path to a .etl trace file.
+// @param system_history The system history to fill.
+// @returns true if the history was filled successfully, false otherwise.
+bool GenerateHistoryFromTrace(const std::wstring& trace_path,
+                              SystemHistory* system_history);
+
+}  // namespace etw_insights

--- a/ETWInsights/etw_reader/stack.h
+++ b/ETWInsights/etw_reader/stack.h
@@ -1,0 +1,26 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace etw_insights {
+
+typedef std::vector<std::string> Stack;
+
+}  // namespace etw_insights

--- a/ETWInsights/etw_reader/system_history.cc
+++ b/ETWInsights/etw_reader/system_history.cc
@@ -1,0 +1,46 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "etw_reader/system_history.h"
+
+namespace etw_insights {
+
+SystemHistory::SystemHistory()
+    : first_event_ts_(0),
+      last_event_ts_(base::kInvalidTimestamp),
+      first_non_empty_paint_ts_(base::kInvalidTimestamp) {}
+
+ThreadHistory& SystemHistory::GetThread(base::Tid tid) {
+  auto look = threads_.find(tid);
+  if (look != threads_.end())
+    return look->second;
+  threads_[tid] = ThreadHistory(tid);
+  return threads_[tid];
+}
+
+void SystemHistory::SetProcessName(base::Pid process_id,
+                                   const std::string& process_name) {
+  process_names_[process_id] = process_name;
+}
+
+const std::string& SystemHistory::GetProcessName(base::Pid process_id) const {
+  auto look = process_names_.find(process_id);
+  if (look == process_names_.end())
+    return empty_string_;
+  return look->second;
+}
+
+}  // namespace etw_insights

--- a/ETWInsights/etw_reader/system_history.h
+++ b/ETWInsights/etw_reader/system_history.h
@@ -1,0 +1,81 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <unordered_map>
+
+#include "base/base.h"
+#include "base/types.h"
+#include "etw_reader/thread_history.h"
+
+namespace etw_insights {
+
+// Contains the history of a system for the duration of a trace.
+class SystemHistory {
+ public:
+  typedef std::unordered_map<base::Tid, ThreadHistory> ThreadHistoryMap;
+
+  SystemHistory();
+
+  ThreadHistory& GetThread(base::Tid tid);
+
+  void set_first_event_ts(base::Timestamp ts) { first_event_ts_ = ts; }
+  base::Timestamp first_event_ts() const { return first_event_ts_; }
+
+  void set_last_event_ts(base::Timestamp ts) { last_event_ts_ = ts; }
+  base::Timestamp last_event_ts() const { return last_event_ts_; }
+
+  void set_first_non_empty_paint_ts(base::Timestamp ts) {
+    first_non_empty_paint_ts_ = ts;
+  }
+  base::Timestamp first_non_empty_paint_ts() const {
+    return first_non_empty_paint_ts_;
+  }
+
+  void SetProcessName(base::Pid process_id, const std::string& process_name);
+  const std::string& GetProcessName(base::Pid process_id) const;
+
+  ThreadHistoryMap::const_iterator threads_begin() const {
+    return threads_.begin();
+  }
+  ThreadHistoryMap::const_iterator threads_end() const {
+    return threads_.end();
+  }
+
+ private:
+  // Empty string.
+  std::string empty_string_;
+
+  // Timestamp of the first event.
+  base::Timestamp first_event_ts_;
+
+  // Timestamp of the last event.
+  base::Timestamp last_event_ts_;
+
+  // Timestamp of the first non empty paint, in Chrome.
+  base::Timestamp first_non_empty_paint_ts_;
+
+  // History of each thread.
+  ThreadHistoryMap threads_;
+
+  // Process names (Process ID -> Process Name).
+  std::unordered_map<base::Pid, std::string> process_names_;
+
+  DISALLOW_COPY_AND_ASSIGN(SystemHistory);
+};
+
+}  // namespace etw_insights

--- a/ETWInsights/etw_reader/thread_history.h
+++ b/ETWInsights/etw_reader/thread_history.h
@@ -1,0 +1,73 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "base/history.h"
+#include "base/types.h"
+#include "etw_reader/stack.h"
+
+namespace etw_insights {
+
+// Contains the history of a thread for the duration of a trace.
+class ThreadHistory {
+ public:
+  ThreadHistory()
+      : tid_(base::kInvalidTid),
+        start_ts_(base::kInvalidTimestamp),
+        end_ts_(base::kInvalidTimestamp),
+        parent_process_id_(base::kInvalidPid) {}
+  ThreadHistory(base::Tid tid)
+     : tid_(tid),
+       start_ts_(base::kInvalidTimestamp),
+       end_ts_(base::kInvalidTimestamp),
+       parent_process_id_(base::kInvalidPid) {}
+
+  base::Tid tid() const { return tid_; }
+
+  void set_start_ts(base::Timestamp ts) { start_ts_ = ts; }
+  base::Timestamp start_ts() const { return start_ts_; }
+
+  void set_end_ts(base::Timestamp ts) { end_ts_ = ts; }
+  base::Timestamp end_ts() const { return end_ts_; }
+
+  void set_parent_process_id(base::Pid parent_process_id) {
+    parent_process_id_ = parent_process_id;
+  }
+  base::Timestamp parent_process_id() const { return parent_process_id_; }
+
+  typedef base::History<Stack> StackHistory;
+  StackHistory& Stacks() { return stacks_; }
+  const StackHistory& Stacks() const { return stacks_; }
+
+ private:
+  // Thread id.
+  base::Tid tid_;
+
+  // Start timestamp.
+  base::Timestamp start_ts_;
+
+  // End timestamp.
+  base::Timestamp end_ts_;
+
+  // Parent process.
+  base::Pid parent_process_id_;
+
+  // Stack history.
+  StackHistory stacks_;
+};
+
+}  // namespace etw_insights

--- a/ETWInsights/flame_graph/clean_stack.cc
+++ b/ETWInsights/flame_graph/clean_stack.cc
@@ -1,0 +1,95 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "flame_graph/clean_stack.h"
+
+#include "base/string_utils.h"
+
+namespace etw_insights {
+
+namespace {
+
+const size_t kMaxStackSize = 60;
+
+std::string CleanSymbol(const std::string& symbol) {
+  // Don't clean special symbols.
+  if (symbol.empty() || symbol.front() == '[')
+    return symbol;
+
+  std::string cleaned_symbol(symbol);
+
+  // Replace semicolons colons.
+  base::ReplaceAll(";", ",", &cleaned_symbol);
+
+  // Remove dll and exe extensions.
+  base::ReplaceAll(".dll!", "!", &cleaned_symbol);
+  base::ReplaceAll(".exe!", "!", &cleaned_symbol);
+
+  return cleaned_symbol;
+}
+
+}  // namespace
+
+Stack CleanStack(const Stack& stack) {
+  Stack cleaned_stack;
+
+  bool is_in_page_fault = false;
+
+  for (auto it = stack.rbegin(); it != stack.rend(); ++it) {
+    // Truncate tall stacks.
+    if (cleaned_stack.size() > kMaxStackSize) {
+      cleaned_stack.push_back("[Tuncated]");
+      break;
+    }
+
+    // Simplify page fault call stack.
+    if (*it == "ntoskrnl.exe!KiPageFault") {
+      is_in_page_fault = true;
+    }
+    if (is_in_page_fault) {
+      if (*it == "[Off-CPU]") {
+        is_in_page_fault = false;
+        cleaned_stack.push_back("[Page Fault]");
+        cleaned_stack.push_back("[Off-CPU]");
+      }
+      continue;
+    }
+
+    // Ignore some symbols at the bottom of the stack.
+    if (*it == "ntdll.dll!_RtlUserThreadStart" ||
+        *it == "ntdll.dll!__RtlUserThreadStart" ||
+        *it == "kernel32.dll!BaseThreadInitThunk" ||
+        *it == "chrome.exe!__tmainCRTStartup") {
+      continue;
+    }
+
+    // Ignore some symbols at the top of the stack.
+    if (*it == "ntoskrnl.exe!SwapContext_PatchLdMxCsr" ||
+        *it == "ntoskrnl.exe!KiSwapContext" ||
+        *it == "ntoskrnl.exe!KiSwapThread" ||
+        *it == "ntoskrnl.exe!KiCommitThreadWait" ||
+        *it == "ntoskrnl.exe!KeWaitForSingoeObject") {
+      continue;
+    }
+
+    // Add the symbol to the cleaned stack.
+    cleaned_stack.push_back(CleanSymbol(*it));
+  }
+
+  return cleaned_stack;
+}
+
+}  // namespace etw_insights

--- a/ETWInsights/flame_graph/clean_stack.h
+++ b/ETWInsights/flame_graph/clean_stack.h
@@ -1,0 +1,31 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "etw_reader/stack.h"
+
+#include <string>
+
+namespace etw_insights {
+
+// Cleans a call stack.
+// - Tall call stacks are truncated.
+// - Frames related to page faults are replaced by [Page Fault].
+// - Uninteresting frames are removed.
+Stack CleanStack(const Stack& stack);
+
+}  // namespace etw_insights

--- a/ETWInsights/flame_graph/flame_graph.cc
+++ b/ETWInsights/flame_graph/flame_graph.cc
@@ -1,0 +1,140 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "flame_graph/flame_graph.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <fstream>
+
+#include "base/child_process.h"
+#include "base/file.h"
+#include "base/string_utils.h"
+#include "flame_graph/clean_stack.h"
+
+namespace etw_insights {
+
+namespace {
+
+// Ignore call stacks that contain these sequences of frames.
+const char* kSequencesToIgnore[][2] = {
+    {"base::SequencedWorkerPool::Inner::ThreadLoop",
+     "base::WinVistaCondVar::TimedWait"},
+    {"base::SequencedWorkerPool::Inner::ThreadLoop",
+     "base::WinVistaCondVar::Wait"},
+    {"base::SequencedWorkerPool::Worker::Worker", "base::WaitableEvent::Wait"},
+    {"base::MessageLoop::RunHandler", "base::WaitableEvent::Wait"},
+    {"base::MessagePumpDefault::Run", "base::WaitableEvent::TimedWait"},
+    {"base::MessagePumpForIO::DoRunLoop",
+     "base::MessagePumpForIO::WaitForIOCompletion"},
+    {"base::MessagePumpForUI::DoRunLoop", "MsgWaitForMultipleObjectsEx"},
+    {"base::trace_event::TraceEventETWExport::ETWKeywordUpdateThread::"
+     "ThreadMain",
+     "base::PlatformThread::Sleep"},
+    {"cc::TaskGraphRunner::Run", "base::WinVistaCondVar::Wait"},
+    {"MojoWaitMany", "mojo::system::Core::WaitMany"},
+    {"TppWorkerThread", "ZwWaitForWorkViaWorkerFactory"},
+    {"sandbox::BrokerServicesBase::TargetEventsThread",
+     "GetQueuedCompletionStatus"},
+};
+const size_t kSequencesToIgnoreSize = ARRAYSIZE(kSequencesToIgnore);
+
+// Ignore call stacks that contain these frames.
+const char* kFramesToIgnore[] = {
+    "EtwpQueueStackWalkApc", "EtwpTraceStackWalk", "EtwpLogKernelEvent",
+};
+const size_t kFramesToIgnoreSize = ARRAYSIZE(kFramesToIgnore);
+
+bool ShouldIgnoreStack(const Stack& stack) {
+  if (stack.empty())
+    return true;
+
+  bool is_off_cpu = stack.front() == "[Off-CPU]";
+
+  for (auto it = stack.rbegin(); it != stack.rend(); ++it) {
+    // Ignore sequences of frames.
+    auto next_it = it + 1;
+    if (is_off_cpu && next_it != stack.rend()) {
+      for (size_t sequence_index = 0; sequence_index < kSequencesToIgnoreSize;
+           ++sequence_index) {
+        if (base::StringEndsWith(*it, kSequencesToIgnore[sequence_index][0]) &&
+            base::StringEndsWith(*next_it,
+                                 kSequencesToIgnore[sequence_index][1])) {
+          return true;
+        }
+      }
+    }
+
+    // Ignore single frames.
+    for (size_t frame_index = 0; frame_index < kFramesToIgnoreSize;
+         ++frame_index) {
+      if (base::StringEndsWith(*it, kFramesToIgnore[frame_index]))
+        return true;
+    }
+  }
+
+  return false;
+}
+
+}  // namespace
+
+FlameGraph::FlameGraph() {}
+
+void FlameGraph::AddThreadHistory(const ThreadHistory& thread_history,
+                                  base::Timestamp start_ts,
+                                  base::Timestamp end_ts) {
+  auto it = thread_history.Stacks().IteratorFromTimestamp(start_ts);
+  auto end_it = thread_history.Stacks().IteratorEnd();
+
+  for (; it != end_it && it->start_ts < end_ts; ++it) {
+    base::Timestamp stack_start_ts = max(start_ts, it->start_ts);
+
+    base::Timestamp stack_end_ts = min(end_ts, thread_history.end_ts());
+    auto next_it = it + 1;
+    if (next_it != end_it && next_it->start_ts < stack_end_ts)
+      stack_end_ts = next_it->start_ts;
+
+    if (stack_end_ts < stack_start_ts) {
+      continue;
+    }
+
+    base::Timestamp stack_duration = stack_end_ts - stack_start_ts;
+    stack_time_[it->value] += stack_duration;
+  }
+}
+
+void FlameGraph::WriteTxtReport(const std::wstring& path) {
+  std::ofstream out(path, std::ios::binary);
+
+  for (const auto& stack_and_time : stack_time_) {
+    if (ShouldIgnoreStack(stack_and_time.first))
+      continue;
+
+    Stack stack = CleanStack(stack_and_time.first);
+    bool first = true;
+    for (const auto& symbol : stack) {
+      if (!first)
+        out << ";";
+      first = false;
+      out << symbol;
+    }
+
+    out << " " << stack_and_time.second << "\n";
+  }
+}
+
+}  // namespace etw_insights

--- a/ETWInsights/flame_graph/flame_graph.h
+++ b/ETWInsights/flame_graph/flame_graph.h
@@ -1,0 +1,45 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <map>
+
+#include "base/base.h"
+#include "base/types.h"
+#include "etw_reader/thread_history.h"
+
+namespace etw_insights {
+
+class FlameGraph {
+ public:
+  FlameGraph();
+
+  void AddThreadHistory(const ThreadHistory& thread_history,
+                        base::Timestamp start_ts,
+                        base::Timestamp end_ts);
+
+  void WriteTxtReport(const std::wstring& path);
+
+ private:
+  // Map: Stack -> Total time spent in the call stack.
+  typedef std::map<Stack, base::Timestamp> StackTimeMap;
+  StackTimeMap stack_time_;
+
+  DISALLOW_COPY_AND_ASSIGN(FlameGraph);
+};
+
+}  // namespace etw_insights

--- a/ETWInsights/flame_graph/flame_graph.vcxproj
+++ b/ETWInsights/flame_graph/flame_graph.vcxproj
@@ -1,0 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{EE253535-588A-4ABC-A65E-8DE45E240D7F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>flame_graph</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="clean_stack.cc" />
+    <ClCompile Include="flame_graph.cc" />
+    <ClCompile Include="main.cc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="clean_stack.h" />
+    <ClInclude Include="flame_graph.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\base\base.vcxproj">
+      <Project>{637388ca-e6e9-4d38-8dc9-cc2fe937de24}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\etw_reader\etw_reader.vcxproj">
+      <Project>{e1fcfe0c-b8cb-4516-9f46-54c1f73a9601}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/ETWInsights/flame_graph/flame_graph.vcxproj.filters
+++ b/ETWInsights/flame_graph/flame_graph.vcxproj.filters
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="clean_stack.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="flame_graph.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="main.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="clean_stack.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="flame_graph.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/ETWInsights/flame_graph/main.cc
+++ b/ETWInsights/flame_graph/main.cc
@@ -1,0 +1,121 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#undef min
+#undef max
+
+#include <iostream>
+
+#include "base/command_line.h"
+#include "base/logging.h"
+#include "base/numeric_conversions.h"
+#include "base/string_utils.h"
+#include "etw_reader/generate_history_from_trace.h"
+#include "etw_reader/system_history.h"
+#include "flame_graph/flame_graph.h"
+
+using namespace etw_insights;
+
+namespace {
+
+// Suffix for a flame graph file name.
+const wchar_t kFlameGraphFileNameSuffix[] = L".flamegraph.txt";
+
+}  // namespace
+
+int wmain(int argc, wchar_t* argv[], wchar_t* /*envp */ []) {
+  // Read command line arguments.
+  base::CommandLine command_line(argc, argv);
+
+  std::wstring trace_path = command_line.GetSwitchValue(L"trace");
+  if (trace_path.empty()) {
+    std::cout << "Please specify a trace path (--trace)." << std::endl;
+    return 1;
+  }
+
+  std::wstring thread_id_filter_str = command_line.GetSwitchValue(L"tid");
+  uint64_t thread_id_filter = base::kInvalidTid;
+  if (!thread_id_filter_str.empty() &&
+      !base::StrToULong(thread_id_filter_str, &thread_id_filter)) {
+    std::cout << "Thread id must be numeric (--tid)." << std::endl;
+    return 1;
+  }
+
+  std::string process_name_filter(
+      base::WStringToString(command_line.GetSwitchValue(L"process_name")));
+
+  uint64_t start_ts = 0;
+  base::StrToULong(command_line.GetSwitchValue(L"start_ts"), &start_ts);
+
+  uint64_t end_ts = base::kInvalidTimestamp;
+  base::StrToULong(command_line.GetSwitchValue(L"end_ts"), &end_ts);
+
+  std::wstring output_path(command_line.GetSwitchValue(L"out"));
+
+  // Generate a system history from the trace.
+  SystemHistory system_history;
+  if (!GenerateHistoryFromTrace(trace_path, &system_history)) {
+    LOG(ERROR) << "Error while generating history from trace.";
+    return 1;
+  }
+
+  // Determine the end time of the analysis.
+  base::Timestamp analysis_end_ts =
+      std::min(std::min(end_ts, system_history.last_event_ts()),
+               system_history.first_non_empty_paint_ts());
+
+  // Tell the user what we are doing.
+  LOG(INFO) << "Generating flame graph." << std::endl;
+
+  // Create a flame graph.
+  FlameGraph flame_graph;
+
+  // Traverse all threads and add those that match the filter to the history.
+  for (auto threads_it = system_history.threads_begin();
+       threads_it != system_history.threads_end(); ++threads_it) {
+    // Thread id filter.
+    if (thread_id_filter != base::kInvalidTid &&
+        thread_id_filter != threads_it->first)
+      continue;
+
+    // Process name filter.
+    if (!process_name_filter.empty()) {
+      std::string process_name =
+          system_history.GetProcessName(threads_it->second.parent_process_id());
+      if (process_name_filter != process_name)
+        continue;
+    }
+
+    // The current thread matches the filter. Add it to the flame graph.
+    flame_graph.AddThreadHistory(
+        threads_it->second,
+        std::max(start_ts, system_history.first_event_ts()),
+        analysis_end_ts);
+  }
+
+  // Write the flame graph in a text file.
+  if (output_path.empty())
+    output_path = trace_path + kFlameGraphFileNameSuffix;
+  flame_graph.WriteTxtReport(output_path);
+
+  // Tell the user that the flame graph was generated.
+  LOG(INFO) << "Wrote flame graph data in file "
+      << base::WStringToString(output_path);
+
+  return 0;
+}


### PR DESCRIPTION
A flame graph is a tool to visualize frequent call stacks efficiently.
Contrary to the existing flame graph functionality of UIforETW, this
tool generates a flame graph that includes off-CPU time. Knowledge of
Chrome is bundled into the tool to ignore uninteresting off-CPU time
(e.g. message loop waiting for a new task to execute).

Usage of the tool is described in ETWInsights\README.md.

Code to read an ETW trace that is not specific to flame graph
generation resides in the ETWInsights\src\etw_reader, as it could be
reused to build other tools (e.g. an ETW to chrome://tracing
converter).