### PR TITLE
Show flame_graph.exe usage when incorrect arguments are specified.

### DIFF
--- a/ETWInsights/README.md
+++ b/ETWInsights/README.md
@@ -5,15 +5,15 @@
 flame_graph is a command-line tool to generate a
 [flame graph](http://www.brendangregg.com/flamegraphs.html) from an ETW trace.
 
-Usage: `flame_graph.exe --trace trace_file_path [options]`
+Usage: `flame_graph.exe --trace <trace_file_path> [options]`
 
 Options:
 
-- `--process_name`: Only show stacks from processes with the specified name.
-- `--tid`: Only show stacks from the specified thread.
-- `--start_ts`: Only show stacks that occurred after the specified timestamp.
-- `--end_ts`: Only show stacks that occurred before the specified timestamp.
-- `--out`: Output file path. Default: flamegraph.txt
+- `--process_name`: Only include stacks from processes with the specified name.
+- `--tid`: Only include stacks from the specified thread.
+- `--start_ts`: Only include stacks that occurred after the specified timestamp.
+- `--end_ts`: Only include stacks that occurred before the specified timestamp.
+- `--out`: Output file path. Default: <trace_file_path>.flamegraph.txt
 
 Timestamps are a number of microseconds elapsed since the beginning of the
 trace.

--- a/ETWInsights/base/command_line.h
+++ b/ETWInsights/base/command_line.h
@@ -39,6 +39,11 @@ class CommandLine {
   //    value was specified for the switch in the command line.
   std::wstring GetSwitchValue(const std::wstring& switch_name) const;
 
+  // @returns the number of command-line switches.
+  size_t GetNumSwitches() const {
+    return switches_.size();
+  }
+
  private:
   // Map Switch Name -> Switch Value.
   std::unordered_map<std::wstring, std::wstring> switches_;

--- a/ETWInsights/flame_graph/main.cc
+++ b/ETWInsights/flame_graph/main.cc
@@ -36,15 +36,42 @@ namespace {
 // Suffix for a flame graph file name.
 const wchar_t kFlameGraphFileNameSuffix[] = L".flamegraph.txt";
 
+void ShowUsage() {
+  std::cout
+      << "Usage: flame_graph.exe --trace <trace_file_path> [options]"
+      << std::endl
+      << std::endl
+      << "Options:" << std::endl
+      << "  --process_name: Only include stacks from processes with the "
+         "specified name."
+      << std::endl
+      << "  --tid: Only include stacks from the specified thread." << std::endl
+      << "  --start_ts: Only include stacks that occurred after the specified "
+         "timestamp."
+      << std::endl
+      << "  --end_ts: Only include stacks that occurred before the specified "
+         "timestamp."
+      << std::endl
+      << "  --out: Output file path. Default: <trace_file_path>.flamegraph.txt"
+      << std::endl;
+}
+
 }  // namespace
 
 int wmain(int argc, wchar_t* argv[], wchar_t* /*envp */ []) {
   // Read command line arguments.
   base::CommandLine command_line(argc, argv);
 
+  if (command_line.GetNumSwitches() == 0) {
+    ShowUsage();
+    return 1;
+  }
+
   std::wstring trace_path = command_line.GetSwitchValue(L"trace");
   if (trace_path.empty()) {
-    std::cout << "Please specify a trace path (--trace)." << std::endl;
+    std::cout << "Please specify a trace path (--trace)." << std::endl
+              << std::endl;
+    ShowUsage();
     return 1;
   }
 
@@ -52,7 +79,8 @@ int wmain(int argc, wchar_t* argv[], wchar_t* /*envp */ []) {
   uint64_t thread_id_filter = base::kInvalidTid;
   if (!thread_id_filter_str.empty() &&
       !base::StrToULong(thread_id_filter_str, &thread_id_filter)) {
-    std::cout << "Thread id must be numeric (--tid)." << std::endl;
+    std::cout << "Thread id must be numeric (--tid)." << std::endl << std::endl;
+    ShowUsage();
     return 1;
   }
 
@@ -115,7 +143,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* /*envp */ []) {
 
   // Tell the user that the flame graph was generated.
   LOG(INFO) << "Wrote flame graph data in file "
-      << base::WStringToString(output_path);
+            << base::WStringToString(output_path);
 
   return 0;
 }


### PR DESCRIPTION
With this CL, a short description of the arguments of
flame_graph.exe is shown when no arguments or invalid arguments
are specified.