### PR TITLE
Source compatibility with clang.

### DIFF
--- a/UIforETW/KeyLoggerThread.cpp
+++ b/UIforETW/KeyLoggerThread.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 namespace
 {
 
-std::atomic<bool> g_LogKeyboardDetails = false;
+std::atomic<bool> g_LogKeyboardDetails(false);
 
 _Pre_satisfies_(nCode == HC_ACTION)
 LRESULT CALLBACK LowLevelKeyboardHook(int nCode, WPARAM wParam, LPARAM lParam)

--- a/UIforETW/UIforETW.cpp
+++ b/UIforETW/UIforETW.cpp
@@ -53,7 +53,7 @@ struct HMODULEhelper
 
 };
 
-typedef WINBASEAPI BOOL(WINAPI* SetProcessMitigationPolicy_t)(\
+typedef BOOL(WINAPI* SetProcessMitigationPolicy_t)(\
 	_In_ _Const_ PROCESS_MITIGATION_POLICY MitigationPolicy,
 	_In_reads_bytes_( dwLength ) _Const_ PVOID lpBuffer,
 	_In_ _Const_ SIZE_T dwLength);

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -185,14 +185,14 @@ BEGIN_MESSAGE_MAP(CUIforETWDlg, CDialog)
 	ON_BN_CLICKED(IDC_SHOWCOMMANDS, &CUIforETWDlg::OnBnClickedShowcommands)
 	ON_BN_CLICKED(IDC_FASTSAMPLING, &CUIforETWDlg::OnBnClickedFastsampling)
 	ON_CBN_SELCHANGE(IDC_INPUTTRACING, &CUIforETWDlg::OnCbnSelchangeInputtracing)
-	ON_MESSAGE(WM_UPDATETRACELIST, UpdateTraceListHandler)
+	ON_MESSAGE(WM_UPDATETRACELIST, &CUIforETWDlg::UpdateTraceListHandler)
 	ON_LBN_DBLCLK(IDC_TRACELIST, &CUIforETWDlg::OnLbnDblclkTracelist)
 	ON_WM_GETMINMAXINFO()
 	ON_WM_SIZE()
 	ON_LBN_SELCHANGE(IDC_TRACELIST, &CUIforETWDlg::OnLbnSelchangeTracelist)
 	ON_BN_CLICKED(IDC_ABOUT, &CUIforETWDlg::OnBnClickedAbout)
 	ON_BN_CLICKED(IDC_SAVETRACEBUFFERS, &CUIforETWDlg::OnBnClickedSavetracebuffers)
-	ON_MESSAGE(WM_HOTKEY, OnHotKey)
+	ON_MESSAGE(WM_HOTKEY, &CUIforETWDlg::OnHotKey)
 	ON_WM_CLOSE()
 	ON_CBN_SELCHANGE(IDC_TRACINGMODE, &CUIforETWDlg::OnCbnSelchangeTracingmode)
 	ON_BN_CLICKED(IDC_SETTINGS, &CUIforETWDlg::OnBnClickedSettings)
@@ -525,10 +525,10 @@ std::wstring CUIforETWDlg::wpaDefaultPath() const
 	return wpa81Path_;
 }
 
-std::wstring CUIforETWDlg::GetDirectory(PCWSTR env, const std::wstring& default)
+std::wstring CUIforETWDlg::GetDirectory(PCWSTR env, const std::wstring& defaultDir)
 {
 	// Get a directory (from an environment variable, if set) and make sure it exists.
-	std::wstring result = default;
+	std::wstring result = defaultDir;
 	const std::wstring traceDir = GetEnvironmentVariableString(env);
 	if (!traceDir.empty())
 	{

--- a/UIforETW/UIforETWDlg.h
+++ b/UIforETW/UIforETWDlg.h
@@ -197,8 +197,8 @@ private:
 	void SetSymbolPath();
 	// Call this to retrieve a directory from an environment variable, or use
 	// a default, and make sure it exists.
-	std::wstring GetDirectory(PCWSTR env, const std::wstring& default);
-	void CUIforETWDlg::UpdateTraceList();
+	std::wstring GetDirectory(PCWSTR env, const std::wstring& defaultDir);
+	void UpdateTraceList();
 	void RegisterProviders();
 	void DisablePagingExecutive();
 

--- a/UIforETW/stdafx.h
+++ b/UIforETW/stdafx.h
@@ -24,6 +24,10 @@ limitations under the License.
 // documented as available on the Server Core SKUs.
 #define _AFX_NO_MFC_CONTROLS_IN_DIALOGS
 
+// disable turning old-style unqualified names to pointers to members
+// when used in BEGIN_MESSAGE_MAP
+#define _ATL_ENABLE_PTM_WARNING
+
 #ifndef VC_EXTRALEAN
 #define VC_EXTRALEAN            // Exclude rarely-used stuff from Windows headers
 #endif


### PR DESCRIPTION
This basically just addresses errors and the more 'silly' warnings: dllimport has no effect when defining a typedef and fully qualifying a class member function with its class name is unnecessary and a Microsoft-specific extension when declaring it.