### PR TITLE
add CLR runtime tracing support

### DIFF
--- a/UIforETW/Resource.h
+++ b/UIforETW/Resource.h
@@ -37,6 +37,7 @@
 #define IDC_TRACEDIR                    1019
 #define IDC_EXTRAPROVIDERS              1019
 #define IDC_EXTRAKERNELFLAGS            1019
+#define IDC_CLRTRACING                  1019
 #define IDC_BUTTON1                     1020
 #define IDC_EXTRASTACKWALKS             1020
 #define IDC_TEMPTRACEDIR                1021
@@ -94,7 +95,7 @@
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        136
+#define _APS_NEXT_RESOURCE_VALUE        137
 #define _APS_NEXT_COMMAND_VALUE         32812
 #define _APS_NEXT_CONTROL_VALUE         1034
 #define _APS_NEXT_SYMED_VALUE           101

--- a/UIforETW/Support.cpp
+++ b/UIforETW/Support.cpp
@@ -62,6 +62,7 @@ void CUIforETWDlg::TransferSettings(bool saving)
 		{ L"SampledStacks", &bSampledStacks_ },
 		{ L"FastSampling", &bFastSampling_ },
 		{ L"GPUTracing", &bGPUTracing_ },
+		{ L"CLRTracing", &bCLRTracing_ },
 		{ L"ShowCommands", &bShowCommands_ },
 		{ L"ChromeDeveloper", &bChromeDeveloper_ },
 		{ L"AutoViewTraces", &bAutoViewTraces_ },

--- a/UIforETW/UIforETW.rc
+++ b/UIforETW/UIforETW.rc
@@ -74,6 +74,7 @@ END
 // remains consistent on all systems.
 IDR_MAINFRAME           ICON                    "res\\UIforETW.ico"
 
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // Dialog
@@ -106,13 +107,13 @@ BEGIN
     PUSHBUTTON      "About",IDC_ABOUT,455,7,50,14
     EDITTEXT        IDC_OUTPUT,7,24,453,110,ES_MULTILINE | ES_READONLY | WS_VSCROLL
     PUSHBUTTON      "Close",IDOK,512,7,50,14
-    CONTROL         "&Compress Trace",IDC_COMPRESSTRACE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,28,67,10
+    CONTROL         "&Compress Trace",IDC_COMPRESSTRACE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,24,67,10
     CONTROL         "Context s&witch call stacks",IDC_CONTEXTSWITCHCALLSTACKS,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,42,98,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,36,98,10
     CONTROL         "CP&U sampling call stacks",IDC_CPUSAMPLINGCALLSTACKS,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,56,93,10
-    CONTROL         "&Fast sampling",IDC_FASTSAMPLING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,70,59,10
-    CONTROL         "&GPU tracing",IDC_GPUTRACING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,84,53,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,48,93,10
+    CONTROL         "&Fast sampling",IDC_FASTSAMPLING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,60,59,10
+    CONTROL         "&GPU tracing",IDC_GPUTRACING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,72,53,10
     LTEXT           "&Input tracing:",IDC_INPUTTRACING_LABEL,464,99,45,8
     COMBOBOX        IDC_INPUTTRACING,511,97,51,127,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     COMBOBOX        IDC_TRACINGMODE,464,116,98,133,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
@@ -122,6 +123,7 @@ BEGIN
     LTEXT           "Trace inform&ation:",IDC_STATIC,239,135,60,8
     EDITTEXT        IDC_TRACENOTES,239,145,323,68,ES_MULTILINE | ES_WANTRETURN | WS_VSCROLL
     EDITTEXT        IDC_TRACENAMEEDIT,75,144,160,14,ES_AUTOHSCROLL | ES_WANTRETURN | NOT WS_VISIBLE | NOT WS_TABSTOP
+    CONTROL         "&CLR tracing",IDC_CLRTRACING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,464,84,53,10
 END
 
 IDD_SETTINGS DIALOGEX 0, 0, 401, 178
@@ -293,6 +295,17 @@ IDR_TRACESACCELERATORS ACCELERATORS
 BEGIN
     "^C",           ID_COPYTRACENAME,       ASCII,  NOINVERT
     VK_DELETE,      ID_DELETETRACE,         VIRTKEY, NOINVERT
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_UIFORETW_DIALOG AFX_DIALOG_LAYOUT
+BEGIN
+    0
 END
 
 

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -159,6 +159,7 @@ void CUIforETWDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Control(pDX, IDC_CONTEXTSWITCHCALLSTACKS, btCswitchStacks_);
 	DDX_Control(pDX, IDC_FASTSAMPLING, btFastSampling_);
 	DDX_Control(pDX, IDC_GPUTRACING, btGPUTracing_);
+	DDX_Control(pDX, IDC_CLRTRACING, btCLRTracing_ );
 	DDX_Control(pDX, IDC_SHOWCOMMANDS, btShowCommands_);
 
 	DDX_Control(pDX, IDC_INPUTTRACING, btInputTracing_);
@@ -212,6 +213,7 @@ BEGIN_MESSAGE_MAP(CUIforETWDlg, CDialog)
 	ON_BN_CLICKED(ID_PASTEOVERRIDE, &CUIforETWDlg::NotesPaste)
 	ON_WM_ACTIVATE()
 	ON_WM_TIMER()
+	ON_BN_CLICKED( IDC_CLRTRACING, &CUIforETWDlg::OnBnClickedClrtracing )
 END_MESSAGE_MAP()
 
 
@@ -424,6 +426,7 @@ BOOL CUIforETWDlg::OnInitDialog()
 	CheckDlgButton(IDC_CPUSAMPLINGCALLSTACKS, bSampledStacks_);
 	CheckDlgButton(IDC_FASTSAMPLING, bFastSampling_);
 	CheckDlgButton(IDC_GPUTRACING, bGPUTracing_);
+	CheckDlgButton(IDC_CLRTRACING, bCLRTracing_);
 	CheckDlgButton(IDC_SHOWCOMMANDS, bShowCommands_);
 
 	// If a fast sampling speed is requested then set it now. Note that
@@ -486,6 +489,7 @@ BOOL CUIforETWDlg::OnInitDialog()
 					L"more practical.");
 		toolTip_.AddTool(&btGPUTracing_, L"Check this to allow seeing GPU usage "
 					L"in WPA, and more data in GPUView.");
+		toolTip_.AddTool(&btCLRTracing_, L"Check this to record CLR call stacks" );
 		toolTip_.AddTool(&btShowCommands_, L"This tells UIforETW to display the commands being "
 					L"executed. This can be helpful for diagnostic purposes but is not normally needed.");
 
@@ -651,6 +655,7 @@ void CUIforETWDlg::UpdateEnabling()
 	SmartEnableWindow(btSampledStacks_.m_hWnd, !bIsTracing_);
 	SmartEnableWindow(btCswitchStacks_.m_hWnd, !bIsTracing_);
 	SmartEnableWindow(btGPUTracing_.m_hWnd, !bIsTracing_);
+	SmartEnableWindow(btCLRTracing_.m_hWnd, !bIsTracing_ );
 }
 
 void CUIforETWDlg::OnSysCommand(UINT nID, LPARAM lParam)
@@ -850,6 +855,18 @@ void CUIforETWDlg::OnBnClickedStarttracing()
 			// DirectX logger:
 			userProviders += L"+DX:0x2F";
 		}
+	}
+
+	if (bCLRTracing_)
+	{
+		// CLR runtime provider
+		// https://msdn.microsoft.com/en-us/library/ff357718(v=vs.100).aspx
+		userProviders += L"+e13c0d23-ccbc-4e12-931b-d9cc2eee27e4:0x1CCBD:0x5";
+        
+		// note: this seems to be an updated version of
+		// userProviders += L"+ClrAll:0x98:5";
+		// which results in Invalid flags. (0x3ec) when I run it
+		// https://msdn.microsoft.com/en-us/library/windows/hardware/hh448186.aspx
 	}
 
 	// Increase the user buffer sizes when doing graphics tracing or Chrome tracing.
@@ -1204,6 +1221,10 @@ void CUIforETWDlg::OnBnClickedGPUtracing()
 	bGPUTracing_ = !bGPUTracing_;
 }
 
+void CUIforETWDlg::OnBnClickedClrtracing()
+{
+	bCLRTracing_ = !bCLRTracing_;
+}
 
 void CUIforETWDlg::OnCbnSelchangeInputtracing()
 {
@@ -1365,6 +1386,7 @@ void CUIforETWDlg::OnSize(UINT nType, int /*cx*/, int /*cy*/)
 			MoveControl(this, btSampledStacks_, xDelta, 0);
 			MoveControl(this, btFastSampling_, xDelta, 0);
 			MoveControl(this, btGPUTracing_, xDelta, 0);
+			MoveControl(this, btCLRTracing_, xDelta, 0 );
 			MoveControl(this, btInputTracingLabel_, xDelta, 0);
 			MoveControl(this, btInputTracing_, xDelta, 0);
 			MoveControl(this, btTracingMode_, xDelta, 0);

--- a/UIforETW/UIforETWDlg.h
+++ b/UIforETW/UIforETWDlg.h
@@ -66,12 +66,14 @@ private:
 	bool bSampledStacks_ = true;
 	bool bFastSampling_ = false;
 	bool bGPUTracing_ = false;
+	bool bCLRTracing_ = false;
 	bool bShowCommands_ = false;
 	CButton btCompress_;
 	CButton btCswitchStacks_;
 	CButton btSampledStacks_;
 	CButton btFastSampling_;
 	CButton btGPUTracing_;
+	CButton btCLRTracing_;
 	CButton btShowCommands_;
 
 	bool bHeapStacks_ = true;
@@ -268,4 +270,5 @@ private:
 	afx_msg void OnTimer(UINT_PTR nIDEvent);
 public:
 	afx_msg void OnBnClickedGPUtracing();
+	afx_msg void OnBnClickedClrtracing();
 };


### PR DESCRIPTION
Add option to record symbols for ngen CLR dlls.

Allows me to see symbols for WindowsBase.ni.dll and PresentationFramework.ni.dll.