### PR TITLE
Allow user to mark regions in a trace

### DIFF
--- a/ETWProviders/etwprof.cpp
+++ b/ETWProviders/etwprof.cpp
@@ -475,4 +475,26 @@ void ETWKeyDown( unsigned nChar, _In_opt_z_ const char* keyName, unsigned nRepCn
 	EventWriteKey_down( nChar, keyName, nRepCnt, flags );
 }
 
+bool ETWUserMarkBegin(int nWhich, int nOccurance)
+{
+	if (!MULTI_MAIN_Context.IsEnabled)
+	{
+		return false;
+	}
+
+	EventWriteUserMarkBegin(nWhich, nOccurance);
+	return true;
+}
+
+bool ETWUserMarkEnd(int nWhich, int nOccurance)
+{
+	if (!MULTI_MAIN_Context.IsEnabled)
+	{
+		return false;
+	}
+
+	EventWriteUserMarkEnd(nWhich, nOccurance);
+	return true;
+}
+
 #endif // ETW_MARKS_ENABLED

--- a/ETWProviders/etwproviders.man
+++ b/ETWProviders/etwproviders.man
@@ -168,6 +168,14 @@ Adjust that to match your games actual install path.
             <data inType="win:Float" name="Percentage"/>
             <data inType="win:UnicodeString" name="Status"/>
           </template>
+          <template tid="T_UserMarkBegin">
+            <data name="Window" inType="win:Int32" outType="xs:int" />
+            <data name="Occurance" inType="win:Int32" outType="xs:int" />
+          </template>
+          <template tid="T_UserMarkEnd">
+            <data name="Window" inType="win:Int32" outType="xs:int" />
+            <data name="Occurance" inType="win:Int32" outType="xs:int" />
+          </template>
         </templates>
         <keywords>
           <keyword name="HighFrequency" mask="0x2" />
@@ -190,6 +198,7 @@ Adjust that to match your games actual install path.
           <task name="TempStatus" symbol="TempStatus_Task" value="7" eventGUID="{D94A8004-28EF-467E-98E2-12B00E3DC1EE}"/>
           <task name="TimerStatus" symbol="TimerStatus_Task" value="8" eventGUID="{F8B8947D-1201-4674-95A5-E1FC60AD92E1}"/>
           <task name="ThrottlingStatus" symbol="ThrottlingStatus_Task" value="9" eventGUID="{49D92EB0-A3D4-4140-B5E1-D12EE17410DB}"/>
+		  <task name="UserMark" symbol="UserMark_Task" value="10" eventGUID="{53277B98-82FB-4315-AAB1-B5FF675AD161}" />
         </tasks>
         <events>
           <event symbol="Start" template="T_Start" value="100" task="Block" opcode="Begin" keywords="NormalFrequency" />
@@ -212,6 +221,8 @@ Adjust that to match your games actual install path.
           <event symbol="Mark4F" template="T_Mark4F" value="117" task="Block" opcode="Mark" keywords="NormalFrequency" />
           <event symbol="Mark3I" template="T_Mark3I" value="118" task="Block" opcode="Mark" keywords="NormalFrequency" />
           <event symbol="Mark4I" template="T_Mark4I" value="119" task="Block" opcode="Mark" keywords="NormalFrequency" />
+		  <event symbol="UserMarkBegin" template="T_UserMarkBegin" value="120" task="UserMark" opcode="Begin" keywords="NormalFrequency" />
+		  <event symbol="UserMarkEnd" template="T_UserMarkEnd" value="121" task="UserMark" opcode="Begin" keywords="NormalFrequency" />
         </events>
       </provider>
 

--- a/UIforETW/UIforETWDlg.h
+++ b/UIforETW/UIforETWDlg.h
@@ -237,6 +237,11 @@ private:
 	void ShutdownTasks();
 	bool bShutdownCompleted_ = false;
 
+	void RegisterHotkeys();
+	void ToggleMark(int index);
+	bool markActive_[10] = {};
+	int markOccurance_[10] = {};
+
 	// Generated message map functions
 	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);

--- a/include/ETWProviders/etwprof.h
+++ b/include/ETWProviders/etwprof.h
@@ -127,6 +127,11 @@ PLATFORM_INTERFACE void __cdecl ETWMouseMove(unsigned flags, int nX, int nY);
 PLATFORM_INTERFACE void __cdecl ETWMouseWheel(unsigned flags, int zDelta, int nX, int nY);
 PLATFORM_INTERFACE void __cdecl ETWKeyDown(unsigned nChar, _In_opt_z_ PCSTR keyName, unsigned nRepCnt, unsigned flags);
 
+// Mark window 
+PLATFORM_INTERFACE bool __cdecl ETWUserMarkBegin(int nWhich, int nOccurance);
+PLATFORM_INTERFACE bool __cdecl ETWUserMarkEnd(int nWhich, int nOccurance);
+
+
 #ifdef __cplusplus
 } // end of extern "C"
 
@@ -192,6 +197,8 @@ inline void ETWMouseUp(int, unsigned int, int, int) {}
 inline void ETWMouseMove(unsigned int, int, int) {}
 inline void ETWMouseWheel(unsigned int, int, int, int) {}
 inline void ETWKeyDown(unsigned, PCSTR, unsigned, unsigned) {}
+inline bool ETWUserMarkBegin(int nWhich, int nOccurance) {}
+inline bool ETWUserMarkEnd(int nWhich, int nOccurance) {}
 
 #ifdef __cplusplus
 // This class calls the ETW Begin and End functions in order to insert a


### PR DESCRIPTION
Don't know if you are interested in this but I found myself wanting to have an easy way to mark regions in a trace to quickly find significant events via a keyboard shortcut.

I've added new keyboard shortcuts Win+Ctrl+Alt+[0-9] to allow 10 separately marked things (probably overkill, I tend to use at most 2), repeatedly hitting them toggles on/off the marking.

I have a custom WPA preset based off your Multi Events with field1 and field2 moved above Opcode Name and filtered to Task Name = UserMark.