### PR TITLE
Persist width and height of UIForETW

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,3 +15,4 @@ Alexander Riccio
 Bradley Grainger
 Michael Winterberg
 Suresh Kumar Ponnusamy
+Chris Davis

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,4 +15,3 @@ Alexander Riccio
 Bradley Grainger
 Michael Winterberg
 Suresh Kumar Ponnusamy
-Chris Davis

--- a/UIforETW/ReadMe.md
+++ b/UIforETW/ReadMe.md
@@ -86,7 +86,7 @@ Most important tasks:
 - [ ] Handle the duplicate copies of etwproviders.man.
 - [ ] Add some unit tests.
 - [ ] Translate the error codes on starting tracing into English, and give advice.
-- [ ] Remember window height
+- [X] Remember window height
 
 To-do eventually:
 - [ ] Should have the option to run arbitrary scripts after each trace is recorded.

--- a/UIforETW/ReadMe.md
+++ b/UIforETW/ReadMe.md
@@ -86,7 +86,7 @@ Most important tasks:
 - [ ] Handle the duplicate copies of etwproviders.man.
 - [ ] Add some unit tests.
 - [ ] Translate the error codes on starting tracing into English, and give advice.
-- [X] Remember window height
+- [ ] Remember window height
 
 To-do eventually:
 - [ ] Should have the option to run arbitrary scripts after each trace is recorded.

--- a/UIforETW/Support.cpp
+++ b/UIforETW/Support.cpp
@@ -91,8 +91,6 @@ void CUIforETWDlg::TransferSettings(bool saving)
 		// settings, to avoid privacy problems.
 		{ L"InputTracing", reinterpret_cast<int*>(&InputTracing_), kKeyLoggerOff, kKeyLoggerAnonymized },
 		{ L"TracingMode", reinterpret_cast<int*>(&tracingMode_), kTracingToMemory, kHeapTracingToFile },
-		{ L"PreviousWidth", &previousWidth_, minWidth_, maxWidth_ },
-		{ L"PreviousHeight", &previousHeight_, minHeight_, maxHeight_ },
 	};
 
 	for (auto& m : ints)

--- a/UIforETW/Support.cpp
+++ b/UIforETW/Support.cpp
@@ -91,6 +91,8 @@ void CUIforETWDlg::TransferSettings(bool saving)
 		// settings, to avoid privacy problems.
 		{ L"InputTracing", reinterpret_cast<int*>(&InputTracing_), kKeyLoggerOff, kKeyLoggerAnonymized },
 		{ L"TracingMode", reinterpret_cast<int*>(&tracingMode_), kTracingToMemory, kHeapTracingToFile },
+		{ L"PreviousWidth", &previousWidth_, minWidth_, maxWidth_ },
+		{ L"PreviousHeight", &previousHeight_, minHeight_, maxHeight_ },
 	};
 
 	for (auto& m : ints)

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -351,8 +351,8 @@ BOOL CUIforETWDlg::OnInitDialog()
 
 	CRect windowRect;
 	GetWindowRect(&windowRect);
-	initialWidth_ = lastWidth_ = windowRect.Width();
-	initialHeight_ = lastHeight_ = windowRect.Height();
+	initialWidth_ = minWidth_ = lastWidth_ = windowRect.Width();
+	initialHeight_ = minHeight_ = lastHeight_ = windowRect.Height();
 
 	// Ensure previousWidth_ and previousHeight_ are valid
 	if (previousWidth_ < initialWidth_)

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -354,6 +354,17 @@ BOOL CUIforETWDlg::OnInitDialog()
 	initialWidth_ = lastWidth_ = windowRect.Width();
 	initialHeight_ = lastHeight_ = windowRect.Height();
 
+	// Ensure previousWidth_ and previousHeight_ are valid
+	if (previousWidth_ < initialWidth_)
+	{
+		previousWidth_ = initialWidth_;
+	}
+
+	if (previousHeight_ < initialHeight_)
+	{
+		previousHeight_ = initialHeight_;
+	}
+
 	// Win+Ctrl+R is used to trigger recording of traces. This is compatible with
 	// wprui. If this is changed then be sure to change the text on *both* buttons
 	// in the main window.
@@ -688,6 +699,10 @@ BOOL CUIforETWDlg::OnInitDialog()
 
 	if (bVersionChecks_)
 		versionCheckerThread_.StartVersionCheckerThread(this);
+
+	const UINT flags = SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOACTIVATE;
+	// Resize our window per the previous dimensions if we have them
+	SetWindowPos(nullptr, 0, 0, previousWidth_, previousHeight_, flags);
 
 	return TRUE; // return TRUE unless you set the focus to a control
 }
@@ -1734,8 +1749,10 @@ void CUIforETWDlg::OnSize(UINT nType, int /*cx*/, int /*cy*/)
 		GetWindowRect(&windowRect);
 		const int xDelta = windowRect.Width() - lastWidth_;
 		lastWidth_ += xDelta;
+		previousWidth_ = lastWidth_;
 		const int yDelta = windowRect.Height() - lastHeight_;
 		lastHeight_ += yDelta;
+		previousHeight_ = lastHeight_;
 
 		const UINT flags = SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOACTIVATE;
 

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -354,17 +354,6 @@ BOOL CUIforETWDlg::OnInitDialog()
 	initialWidth_ = lastWidth_ = windowRect.Width();
 	initialHeight_ = lastHeight_ = windowRect.Height();
 
-	// Ensure previousWidth_ and previousHeight_ are valid
-	if (previousWidth_ < initialWidth_)
-	{
-		previousWidth_ = initialWidth_;
-	}
-
-	if (previousHeight_ < initialHeight_)
-	{
-		previousHeight_ = initialHeight_;
-	}
-
 	// Win+Ctrl+R is used to trigger recording of traces. This is compatible with
 	// wprui. If this is changed then be sure to change the text on *both* buttons
 	// in the main window.
@@ -699,10 +688,6 @@ BOOL CUIforETWDlg::OnInitDialog()
 
 	if (bVersionChecks_)
 		versionCheckerThread_.StartVersionCheckerThread(this);
-
-	const UINT flags = SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOACTIVATE;
-	// Resize our window per the previous dimensions if we have them
-	SetWindowPos(nullptr, 0, 0, previousWidth_, previousHeight_, flags);
 
 	return TRUE; // return TRUE unless you set the focus to a control
 }
@@ -1749,10 +1734,8 @@ void CUIforETWDlg::OnSize(UINT nType, int /*cx*/, int /*cy*/)
 		GetWindowRect(&windowRect);
 		const int xDelta = windowRect.Width() - lastWidth_;
 		lastWidth_ += xDelta;
-		previousWidth_ = lastWidth_;
 		const int yDelta = windowRect.Height() - lastHeight_;
 		lastHeight_ += yDelta;
-		previousHeight_ = lastHeight_;
 
 		const UINT flags = SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOACTIVATE;
 

--- a/UIforETW/UIforETWDlg.h
+++ b/UIforETW/UIforETWDlg.h
@@ -211,6 +211,13 @@ private:
 	int initialHeight_ = 0;
 	int lastWidth_ = 0;
 	int lastHeight_ = 0;
+	const int minWidth_ = 870;
+	const int minHeight_ = 398;
+	const int maxWidth_ = 3000;
+	const int maxHeight_ = 3000;
+	// Width and height persisted to settings
+	int previousWidth_ = 0;
+	int previousHeight_ = 0;
 
 	void SetSymbolPath();
 	// Call this to retrieve a directory from an environment variable, or use

--- a/UIforETW/UIforETWDlg.h
+++ b/UIforETW/UIforETWDlg.h
@@ -211,8 +211,8 @@ private:
 	int initialHeight_ = 0;
 	int lastWidth_ = 0;
 	int lastHeight_ = 0;
-	const int minWidth_ = 870;
-	const int minHeight_ = 398;
+	int minWidth_ = 0;
+	int minHeight_ = 0;
 	const int maxWidth_ = 3000;
 	const int maxHeight_ = 3000;
 	// Width and height persisted to settings

--- a/UIforETW/UIforETWDlg.h
+++ b/UIforETW/UIforETWDlg.h
@@ -211,13 +211,6 @@ private:
 	int initialHeight_ = 0;
 	int lastWidth_ = 0;
 	int lastHeight_ = 0;
-	const int minWidth_ = 870;
-	const int minHeight_ = 398;
-	const int maxWidth_ = 3000;
-	const int maxHeight_ = 3000;
-	// Width and height persisted to settings
-	int previousWidth_ = 0;
-	int previousHeight_ = 0;
 
 	void SetSymbolPath();
 	// Call this to retrieve a directory from an environment variable, or use


### PR DESCRIPTION
This change implements the requested feature to persist the width and height of the UIForETW dialog.  Setting is read during startup and applied to the dialog window upon initialization.  I added a min size which is the default size of the dialog resource.  I also added some arbitrary large max values for the width and height.