### PR TITLE
Enable collection of Performance API events exclusively.

### DIFF
--- a/UIforETW/Settings.cpp
+++ b/UIforETW/Settings.cpp
@@ -57,6 +57,7 @@ const PCWSTR filtered_event_group_names[] =
 	L"disabled-by-default-toplevel.flow",               // 0x2000
 	L"startup",                                         // 0x4000
 	L"latency",                                         // 0x8000
+	L"blink.user_timing",								// 0x10000
 };
 
 // 1ULL << 61 and 1ULL << 62 are special values that indicate to Chrome to

--- a/UIforETW/Settings.cpp
+++ b/UIforETW/Settings.cpp
@@ -57,7 +57,7 @@ const PCWSTR filtered_event_group_names[] =
 	L"disabled-by-default-toplevel.flow",               // 0x2000
 	L"startup",                                         // 0x4000
 	L"latency",                                         // 0x8000
-	L"blink.user_timing",								// 0x10000
+	L"blink.user_timing",                               // 0x10000
 };
 
 // 1ULL << 61 and 1ULL << 62 are special values that indicate to Chrome to


### PR DESCRIPTION
Performance API events are logged via the blink.user_timing category.  This change adds that category to the list of those available in UIforETW to log only those events in this category.