### PR TITLE
Fix poor detection of a dupe instance

### DIFF
--- a/UIforETW/UIforETW.h
+++ b/UIforETW/UIforETW.h
@@ -37,9 +37,11 @@ public:
 	virtual BOOL InitInstance() override;
 	afx_msg void OnHelp() noexcept;
 
+	static BOOL CALLBACK findDupeWindow(HWND hWnd, LPARAM lParam);
 // Implementation
 
 	DECLARE_MESSAGE_MAP()
 };
 
+inline const UINT uwmAreYouMe = RegisterWindowMessage(L"678fd291e05741edb987c0a4f5650866");
 extern CUIforETWApp theApp;

--- a/UIforETW/UIforETWDlg.cpp
+++ b/UIforETW/UIforETWDlg.cpp
@@ -260,6 +260,7 @@ BEGIN_MESSAGE_MAP(CUIforETWDlg, CDialog)
 	ON_WM_ACTIVATE()
 	ON_WM_TIMER()
 	ON_BN_CLICKED(IDC_CLRTRACING, &CUIforETWDlg::OnBnClickedClrtracing)
+	ON_REGISTERED_MESSAGE(uwmAreYouMe, &CUIforETWDlg::OnAreYouMe)
 END_MESSAGE_MAP()
 
 
@@ -2537,4 +2538,9 @@ void CUIforETWDlg::OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized)
 		SaveNotesIfNeeded();
 	}
 	CDialog::OnActivate(nState, pWndOther, bMinimized);
+}
+
+LRESULT CUIforETWDlg::OnAreYouMe(WPARAM, LPARAM) noexcept
+{
+	return uwmAreYouMe;
 }

--- a/UIforETW/UIforETWDlg.h
+++ b/UIforETW/UIforETWDlg.h
@@ -258,6 +258,7 @@ private:
 	bool bShutdownCompleted_ = false;
 
 	// Generated message map functions
+	afx_msg LRESULT OnAreYouMe(WPARAM, LPARAM) noexcept;
 	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	afx_msg void OnPaint();


### PR DESCRIPTION
Old FindWindow() function could mistake an Explorer folder 'UI for ETW'
for another instance of 'UI for ETW' (since window title is identical)
New custom function registers a unique window message that allows to
uniquely identify another instance of 'UI for ETW'
Bonus: restore the minimized window of 'UI for ETW'

Resolves: #147